### PR TITLE
Add polygon and curved-path building footprint templates

### DIFF
--- a/src/building-coordinates.test.ts
+++ b/src/building-coordinates.test.ts
@@ -310,6 +310,11 @@ describe("templateBounds with a path template", () => {
     expect(() => templateBounds(noStart, "path")).toThrow(/start point/i);
   });
 
+  it("throws when start is not a 2-number point", () => {
+    const badStart = { ...pathTemplate, start: [] } as unknown as Template;
+    expect(() => templateBounds(badStart, "path")).toThrow(/start point/i);
+  });
+
   it("throws on fewer than 2 segments", () => {
     expect(() =>
       templateBounds(

--- a/src/building-coordinates.test.ts
+++ b/src/building-coordinates.test.ts
@@ -232,3 +232,41 @@ describe("templateBounds", () => {
     expect(() => templateBounds(poly, "poly")).toThrow(/0,0/);
   });
 });
+
+describe("resolveBuilding with a polygon template", () => {
+  const polyTemplates: Record<string, PolygonTemplate> = {
+    ruins: {
+      points: [
+        [1, 0],
+        [7, 2],
+        [5, 11],
+        [0, 6],
+      ],
+    },
+  };
+
+  it("places a polygon by pinning its bounding-box corners", () => {
+    // The polygon's bbox is 7x11, so TL->TR must span 7.
+    const result = resolveBuilding(
+      { type: "ruins", mirror: false, corners: { TL: [10, 5], TR: [17, 5] } },
+      polyTemplates,
+      canvas,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].templateName).toBe("ruins");
+    expect(result[0].translate[0]).toBeCloseTo(10);
+    expect(result[0].translate[1]).toBeCloseTo(5);
+    expect(result[0].rotation).toBeCloseTo(0);
+  });
+
+  it("throws when a corner span disagrees with the polygon bbox edge", () => {
+    // TL->TR span is 6 but the polygon bbox's TL->TR edge is 7.
+    expect(() =>
+      resolveBuilding(
+        { type: "ruins", corners: { TL: [10, 5], TR: [16, 5] } },
+        polyTemplates,
+        canvas,
+      ),
+    ).toThrow(/template edge/i);
+  });
+});

--- a/src/building-coordinates.test.ts
+++ b/src/building-coordinates.test.ts
@@ -4,7 +4,11 @@ import {
   resolveBuilding,
   templateBounds,
 } from "./building-coordinates";
-import type { PolygonTemplate } from "./building-coordinates";
+import type {
+  PolygonTemplate,
+  PathTemplate,
+  Template,
+} from "./building-coordinates";
 
 const canvas = { width: 60, height: 44 };
 
@@ -268,5 +272,80 @@ describe("resolveBuilding with a polygon template", () => {
         canvas,
       ),
     ).toThrow(/template edge/i);
+  });
+});
+
+describe("templateBounds with a path template", () => {
+  const pathTemplate: PathTemplate = {
+    width: 8,
+    height: 8,
+    start: [4, 0],
+    segments: [
+      { cubic: [8, 4], controls: [[6, 0], [8, 2]] },
+      { line: [4, 8] },
+      { quad: [0, 4], control: [0, 8] },
+      { line: [4, 0] },
+    ],
+  };
+
+  it("returns the declared size for a path template", () => {
+    expect(templateBounds(pathTemplate, "path")).toEqual({
+      width: 8,
+      height: 8,
+    });
+  });
+
+  it("throws on a non-positive width or height", () => {
+    expect(() => templateBounds({ ...pathTemplate, width: 0 }, "path")).toThrow(
+      /positive width and height/i,
+    );
+  });
+
+  it("throws when start is missing", () => {
+    const noStart = {
+      width: 8,
+      height: 8,
+      segments: pathTemplate.segments,
+    } as unknown as Template;
+    expect(() => templateBounds(noStart, "path")).toThrow(/start point/i);
+  });
+
+  it("throws on fewer than 2 segments", () => {
+    expect(() =>
+      templateBounds(
+        { ...pathTemplate, segments: [{ line: [4, 0] }] },
+        "path",
+      ),
+    ).toThrow(/at least 2 segments/i);
+  });
+});
+
+describe("resolveBuilding with a path template", () => {
+  const pathTemplates: Record<string, PathTemplate> = {
+    bastion: {
+      width: 8,
+      height: 8,
+      start: [4, 0],
+      segments: [
+        { cubic: [8, 4], controls: [[6, 0], [8, 2]] },
+        { cubic: [4, 8], controls: [[8, 6], [6, 8]] },
+        { cubic: [0, 4], controls: [[2, 8], [0, 6]] },
+        { cubic: [4, 0], controls: [[0, 2], [2, 0]] },
+      ],
+    },
+  };
+
+  it("places a path template by pinning its declared bounding-box corners", () => {
+    // The declared bbox is 8x8, so TL->TR must span 8.
+    const result = resolveBuilding(
+      { type: "bastion", mirror: false, corners: { TL: [10, 5], TR: [18, 5] } },
+      pathTemplates,
+      canvas,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].templateName).toBe("bastion");
+    expect(result[0].translate[0]).toBeCloseTo(10);
+    expect(result[0].translate[1]).toBeCloseTo(5);
+    expect(result[0].rotation).toBeCloseTo(0);
   });
 });

--- a/src/building-coordinates.test.ts
+++ b/src/building-coordinates.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { resolveCorner, resolveBuilding } from "./building-coordinates";
+import {
+  resolveCorner,
+  resolveBuilding,
+  templateBounds,
+} from "./building-coordinates";
+import type { PolygonTemplate } from "./building-coordinates";
 
 const canvas = { width: 60, height: 44 };
 
@@ -170,5 +175,60 @@ describe("resolveBuilding validation", () => {
         canvas,
       ),
     ).not.toThrow();
+  });
+});
+
+describe("templateBounds", () => {
+  it("returns the stored size for a rectangle template", () => {
+    expect(templateBounds({ width: 4, height: 6 }, "rect")).toEqual({
+      width: 4,
+      height: 6,
+    });
+  });
+
+  it("derives the bounding box from polygon points", () => {
+    const poly: PolygonTemplate = {
+      points: [
+        [0, 0],
+        [7, 0],
+        [7, 11],
+        [0, 11],
+      ],
+    };
+    expect(templateBounds(poly, "poly")).toEqual({ width: 7, height: 11 });
+  });
+
+  it("derives the bounding box from an irregular polygon", () => {
+    const poly: PolygonTemplate = {
+      points: [
+        [1, 0],
+        [7, 2],
+        [5, 11],
+        [0, 6],
+      ],
+    };
+    expect(templateBounds(poly, "poly")).toEqual({ width: 7, height: 11 });
+  });
+
+  it("throws on a polygon with fewer than 3 points", () => {
+    const poly: PolygonTemplate = {
+      points: [
+        [0, 0],
+        [4, 0],
+      ],
+    };
+    expect(() => templateBounds(poly, "poly")).toThrow(/at least 3 points/i);
+  });
+
+  it("throws when the polygon bounding box does not start at 0,0", () => {
+    const poly: PolygonTemplate = {
+      points: [
+        [2, 1],
+        [9, 1],
+        [9, 12],
+        [2, 12],
+      ],
+    };
+    expect(() => templateBounds(poly, "poly")).toThrow(/0,0/);
   });
 });

--- a/src/building-coordinates.ts
+++ b/src/building-coordinates.ts
@@ -92,17 +92,20 @@ export type ResolvedBuilding = {
   rotation: number; // degrees, [0, 360)
 };
 
-/** Template-local position of a named rectangle corner. */
-function localCorner(corner: Anchor, t: RectTemplate): Point {
+/** Template-local position of a named bounding-box corner. */
+function localCorner(
+  corner: Anchor,
+  size: { width: number; height: number },
+): Point {
   switch (corner) {
     case "TL":
       return [0, 0];
     case "TR":
-      return [t.width, 0];
+      return [size.width, 0];
     case "BR":
-      return [t.width, t.height];
+      return [size.width, size.height];
     case "BL":
-      return [0, t.height];
+      return [0, size.height];
   }
 }
 
@@ -121,7 +124,7 @@ function rotate(p: Point, rad: number): Point {
  */
 export function resolveBuilding(
   placement: BuildingPlacement,
-  templates: Record<string, RectTemplate>,
+  templates: Record<string, Template>,
   canvas: CanvasSize,
 ): ResolvedBuilding[] {
   const template = templates[placement.type];
@@ -141,8 +144,9 @@ export function resolveBuilding(
   const [[cornerA, specA], [cornerB, specB]] = entries;
   const pA = resolveCorner(specA, defaultFrom, canvas);
   const pB = resolveCorner(specB, defaultFrom, canvas);
-  const lA = localCorner(cornerA, template);
-  const lB = localCorner(cornerB, template);
+  const size = templateBounds(template, placement.type);
+  const lA = localCorner(cornerA, size);
+  const lB = localCorner(cornerB, size);
 
   const targetLength = Math.hypot(pB[0] - pA[0], pB[1] - pA[1]);
   const templateLength = Math.hypot(lB[0] - lA[0], lB[1] - lA[1]);

--- a/src/building-coordinates.ts
+++ b/src/building-coordinates.ts
@@ -84,8 +84,10 @@ export function templateBounds(
         `template ${name}: path needs a positive width and height`,
       );
     }
-    if (!start) {
-      throw new Error(`template ${name}: path needs a start point`);
+    if (!Array.isArray(start) || start.length !== 2) {
+      throw new Error(
+        `template ${name}: path needs a [number, number] start point`,
+      );
     }
     if (!Array.isArray(segments) || segments.length < 2) {
       throw new Error(`template ${name}: path needs at least 2 segments`);

--- a/src/building-coordinates.ts
+++ b/src/building-coordinates.ts
@@ -30,6 +30,55 @@ export function resolveCorner(
 
 export type RectTemplate = { width: number; height: number };
 
+/** A polygon footprint: a closed ring of template-local points. */
+export type PolygonTemplate = { points: Point[] };
+
+/** A building template — either a rectangle or a polygon footprint. */
+export type Template = RectTemplate | PolygonTemplate;
+
+/**
+ * The bounding-box size of a template. A rectangle returns its stored
+ * size; a polygon's size is derived from its points (the bbox origin is
+ * required to be 0,0, so width/height are the maximum x/y). Throws when a
+ * template is neither a valid rectangle nor a valid polygon.
+ */
+export function templateBounds(
+  template: Template,
+  name: string,
+): { width: number; height: number } {
+  if (
+    "points" in template &&
+    ("width" in template || "height" in template)
+  ) {
+    throw new Error(
+      `template ${name}: defines both polygon points and width/height`,
+    );
+  }
+  if ("points" in template) {
+    const { points } = template;
+    if (!Array.isArray(points) || points.length < 3) {
+      throw new Error(`template ${name}: polygon needs at least 3 points`);
+    }
+    const xs = points.map((p) => p[0]);
+    const ys = points.map((p) => p[1]);
+    const minX = Math.min(...xs);
+    const minY = Math.min(...ys);
+    if (minX !== 0 || minY !== 0) {
+      throw new Error(
+        `template ${name}: polygon bounding box must start at 0,0 ` +
+          `(got ${minX},${minY})`,
+      );
+    }
+    return { width: Math.max(...xs), height: Math.max(...ys) };
+  }
+  if ("width" in template && "height" in template) {
+    return { width: template.width, height: template.height };
+  }
+  throw new Error(
+    `template ${name}: must define width/height or polygon points`,
+  );
+}
+
 export type BuildingPlacement = {
   type: string;
   corners: Partial<Record<Anchor, CornerSpec>>; // exactly 2 entries

--- a/src/building-coordinates.ts
+++ b/src/building-coordinates.ts
@@ -33,14 +33,32 @@ export type RectTemplate = { width: number; height: number };
 /** A polygon footprint: a closed ring of template-local points. */
 export type PolygonTemplate = { points: Point[] };
 
-/** A building template — either a rectangle or a polygon footprint. */
-export type Template = RectTemplate | PolygonTemplate;
+/** One segment of a path footprint: a line, quadratic, or cubic Bézier. */
+export type PathSegment =
+  | { line: Point }
+  | { quad: Point; control: Point }
+  | { cubic: Point; controls: [Point, Point] };
 
 /**
- * The bounding-box size of a template. A rectangle returns its stored
- * size; a polygon's size is derived from its points (the bbox origin is
- * required to be 0,0, so width/height are the maximum x/y). Throws when a
- * template is neither a valid rectangle nor a valid polygon.
+ * A freeform curved footprint: a `start` point and an ordered list of
+ * segments (the path auto-closes back to `start`). Its bounding box is
+ * declared, not derived from the geometry.
+ */
+export type PathTemplate = {
+  width: number;
+  height: number;
+  start: Point;
+  segments: PathSegment[];
+};
+
+/** A building template — a rectangle, a polygon, or a curved path. */
+export type Template = RectTemplate | PolygonTemplate | PathTemplate;
+
+/**
+ * The bounding-box size of a template. A rectangle and a path return their
+ * stored/declared size; a polygon's size is derived from its points (the
+ * bbox origin is required to be 0,0, so width/height are the maximum x/y).
+ * Throws when a template is not a valid rectangle, polygon, or path.
  */
 export function templateBounds(
   template: Template,
@@ -53,6 +71,26 @@ export function templateBounds(
     throw new Error(
       `template ${name}: defines both polygon points and width/height`,
     );
+  }
+  if ("segments" in template) {
+    const { width, height, start, segments } = template;
+    if (
+      typeof width !== "number" ||
+      width <= 0 ||
+      typeof height !== "number" ||
+      height <= 0
+    ) {
+      throw new Error(
+        `template ${name}: path needs a positive width and height`,
+      );
+    }
+    if (!start) {
+      throw new Error(`template ${name}: path needs a start point`);
+    }
+    if (!Array.isArray(segments) || segments.length < 2) {
+      throw new Error(`template ${name}: path needs at least 2 segments`);
+    }
+    return { width, height };
   }
   if ("points" in template) {
     const { points } = template;
@@ -75,7 +113,8 @@ export function templateBounds(
     return { width: template.width, height: template.height };
   }
   throw new Error(
-    `template ${name}: must define width/height or polygon points`,
+    `template ${name}: must define width/height, polygon points, or ` +
+      `path segments`,
   );
 }
 

--- a/src/buildings.test.ts
+++ b/src/buildings.test.ts
@@ -210,6 +210,20 @@ describe("path templates", () => {
     );
   });
 
+  it("injectTemplateDefs applies svg properties to a path template", () => {
+    const defs = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "defs",
+    );
+    const templates: Record<string, PathTemplate> = {
+      bastion: { width: 4, height: 4, start, segments },
+    };
+    injectTemplateDefs(templates, defs, { fill: "#808080" });
+    expect(defs.querySelector("#template-bastion")!.getAttribute("fill")).toBe(
+      "#808080",
+    );
+  });
+
   it("makeBuildings emits a <use> referencing a path template", () => {
     const templates: Record<string, PathTemplate> = {
       bastion: {

--- a/src/buildings.test.ts
+++ b/src/buildings.test.ts
@@ -1,6 +1,15 @@
 // @vitest-environment happy-dom
 import { describe, it, expect } from "vitest";
-import { makeBuildings, injectTemplateDefs } from "./buildings";
+import {
+  makeBuildings,
+  injectTemplateDefs,
+  segmentsToPathData,
+} from "./buildings";
+import type {
+  Point,
+  PathSegment,
+  PathTemplate,
+} from "./building-coordinates";
 
 const canvas = { width: 60, height: 44 };
 const templates = {
@@ -160,6 +169,63 @@ describe("polygon templates", () => {
     );
     expect(group.querySelector("use")!.getAttribute("href")).toBe(
       "#template-ruins",
+    );
+  });
+});
+
+describe("path templates", () => {
+  const start: Point = [0, 0];
+  const segments: PathSegment[] = [
+    { line: [4, 0] },
+    { quad: [4, 4], control: [6, 2] },
+    { cubic: [0, 4], controls: [[3, 6], [1, 5]] },
+  ];
+
+  it("segmentsToPathData builds an M/L/Q/C/Z path string", () => {
+    expect(segmentsToPathData(start, segments)).toBe(
+      "M 0 0 L 4 0 Q 6 2 4 4 C 3 6 1 5 0 4 Z",
+    );
+  });
+
+  it("segmentsToPathData throws on an unrecognized segment", () => {
+    expect(() =>
+      segmentsToPathData(start, [{ bogus: [1, 1] }] as unknown as PathSegment[]),
+    ).toThrow(/unrecognized/i);
+  });
+
+  it("injectTemplateDefs emits a <path> for a path template", () => {
+    const defs = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "defs",
+    );
+    const templates: Record<string, PathTemplate> = {
+      bastion: { width: 4, height: 4, start, segments },
+    };
+    injectTemplateDefs(templates, defs);
+    const path = defs.querySelector("#template-bastion");
+    expect(path).not.toBeNull();
+    expect(path!.tagName).toBe("path");
+    expect(path!.getAttribute("d")).toBe(
+      "M 0 0 L 4 0 Q 6 2 4 4 C 3 6 1 5 0 4 Z",
+    );
+  });
+
+  it("makeBuildings emits a <use> referencing a path template", () => {
+    const templates: Record<string, PathTemplate> = {
+      bastion: {
+        width: 8,
+        height: 8,
+        start: [0, 0],
+        segments: [{ line: [8, 0] }, { line: [8, 8] }, { line: [0, 8] }],
+      },
+    };
+    const group = makeBuildings(
+      [{ type: "bastion", mirror: false, corners: { TL: [10, 5], TR: [18, 5] } }],
+      templates,
+      canvas,
+    );
+    expect(group.querySelector("use")!.getAttribute("href")).toBe(
+      "#template-bastion",
     );
   });
 });

--- a/src/buildings.test.ts
+++ b/src/buildings.test.ts
@@ -94,3 +94,72 @@ describe("svg property styling", () => {
     expect(defs.querySelector("#template-4x6")!.getAttribute("fill")).toBeNull();
   });
 });
+
+describe("polygon templates", () => {
+  it("injectTemplateDefs emits a <polygon> for a polygon template", () => {
+    const defs = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "defs",
+    );
+    injectTemplateDefs(
+      {
+        ruins: {
+          points: [
+            [0, 0],
+            [7, 0],
+            [7, 11],
+            [0, 11],
+          ],
+        },
+      },
+      defs,
+    );
+    const poly = defs.querySelector("#template-ruins");
+    expect(poly).not.toBeNull();
+    expect(poly!.tagName).toBe("polygon");
+    expect(poly!.getAttribute("points")).toBe("0,0 7,0 7,11 0,11");
+  });
+
+  it("injectTemplateDefs applies svg properties to a polygon", () => {
+    const defs = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "defs",
+    );
+    injectTemplateDefs(
+      {
+        ruins: {
+          points: [
+            [0, 0],
+            [7, 0],
+            [0, 11],
+          ],
+        },
+      },
+      defs,
+      { fill: "#808080" },
+    );
+    expect(defs.querySelector("#template-ruins")!.getAttribute("fill")).toBe(
+      "#808080",
+    );
+  });
+
+  it("makeBuildings emits a <use> referencing a polygon template", () => {
+    const group = makeBuildings(
+      [{ type: "ruins", mirror: false, corners: { TL: [10, 5], TR: [17, 5] } }],
+      {
+        ruins: {
+          points: [
+            [0, 0],
+            [7, 0],
+            [7, 11],
+            [0, 11],
+          ],
+        },
+      },
+      canvas,
+    );
+    expect(group.querySelector("use")!.getAttribute("href")).toBe(
+      "#template-ruins",
+    );
+  });
+});

--- a/src/buildings.ts
+++ b/src/buildings.ts
@@ -3,14 +3,46 @@ import {
   resolveBuilding,
   type BuildingPlacement,
   type CanvasSize,
+  type PathSegment,
+  type Point,
   type Template,
 } from "./building-coordinates";
 import type { SVGProperties } from "./types";
 
 /**
- * Appends one shape definition per template into `defs`: a `<polygon>` for
- * a polygon template, a `<rect>` for a rectangle. Each carries the id
- * `template-<name>` so a building `<use>` can reference it.
+ * Builds the SVG path `d` data for a closed footprint: a move to `start`,
+ * one command per segment (line / quadratic / cubic Bézier), then `Z`.
+ */
+export function segmentsToPathData(
+  start: Point,
+  segments: PathSegment[],
+): string {
+  let d = `M ${start[0]} ${start[1]}`;
+  for (const segment of segments) {
+    if ("line" in segment) {
+      d += ` L ${segment.line[0]} ${segment.line[1]}`;
+    } else if ("quad" in segment) {
+      const { quad, control } = segment;
+      d += ` Q ${control[0]} ${control[1]} ${quad[0]} ${quad[1]}`;
+    } else if ("cubic" in segment) {
+      const { cubic, controls } = segment;
+      d +=
+        ` C ${controls[0][0]} ${controls[0][1]} ` +
+        `${controls[1][0]} ${controls[1][1]} ${cubic[0]} ${cubic[1]}`;
+    } else {
+      throw new Error(
+        `unrecognized path segment: ${JSON.stringify(segment)}`,
+      );
+    }
+  }
+  return `${d} Z`;
+}
+
+/**
+ * Appends one shape definition per template into `defs`: a `<path>` for a
+ * curved path template, a `<polygon>` for a polygon, a `<rect>` for a
+ * rectangle. Each carries the id `template-<name>` so a building `<use>`
+ * can reference it.
  */
 export function injectTemplateDefs(
   templates: Record<string, Template>,
@@ -19,7 +51,13 @@ export function injectTemplateDefs(
 ): void {
   for (const [name, template] of Object.entries(templates)) {
     let shape: SVGElement;
-    if ("points" in template) {
+    if ("segments" in template) {
+      shape = makeElement("path");
+      shape.setAttribute(
+        "d",
+        segmentsToPathData(template.start, template.segments),
+      );
+    } else if ("points" in template) {
       shape = makeElement("polygon");
       shape.setAttribute(
         "points",

--- a/src/buildings.ts
+++ b/src/buildings.ts
@@ -3,34 +3,47 @@ import {
   resolveBuilding,
   type BuildingPlacement,
   type CanvasSize,
-  type RectTemplate,
+  type Template,
 } from "./building-coordinates";
 import type { SVGProperties } from "./types";
 
-/** Appends one <rect> template definition per template into `defs`. */
+/**
+ * Appends one shape definition per template into `defs`: a `<polygon>` for
+ * a polygon template, a `<rect>` for a rectangle. Each carries the id
+ * `template-<name>` so a building `<use>` can reference it.
+ */
 export function injectTemplateDefs(
-  templates: Record<string, RectTemplate>,
+  templates: Record<string, Template>,
   defs: SVGElement,
   svgProperties?: SVGProperties,
 ): void {
   for (const [name, template] of Object.entries(templates)) {
-    const rect = makeElement("rect");
-    rect.setAttribute("id", `template-${name}`);
-    rect.setAttribute("x", "0");
-    rect.setAttribute("y", "0");
-    rect.setAttribute("width", `${template.width}`);
-    rect.setAttribute("height", `${template.height}`);
-    if (svgProperties) {
-      applyAttributes(rect, svgProperties);
+    let shape: SVGElement;
+    if ("points" in template) {
+      shape = makeElement("polygon");
+      shape.setAttribute(
+        "points",
+        template.points.map((p) => `${p[0]},${p[1]}`).join(" "),
+      );
+    } else {
+      shape = makeElement("rect");
+      shape.setAttribute("x", "0");
+      shape.setAttribute("y", "0");
+      shape.setAttribute("width", `${template.width}`);
+      shape.setAttribute("height", `${template.height}`);
     }
-    defs.appendChild(rect);
+    shape.setAttribute("id", `template-${name}`);
+    if (svgProperties) {
+      applyAttributes(shape, svgProperties);
+    }
+    defs.appendChild(shape);
   }
 }
 
 /** Builds a <g> of <use> elements, one per resolved (and mirrored) building. */
 export function makeBuildings(
   placements: BuildingPlacement[],
-  templates: Record<string, RectTemplate>,
+  templates: Record<string, Template>,
   canvas: CanvasSize,
   svgProperties?: SVGProperties,
 ): SVGElement {

--- a/src/terrain-config.ts
+++ b/src/terrain-config.ts
@@ -7,9 +7,9 @@ export type TerrainLayout = {
 
 /**
  * A terrain file as parsed from YAML: a set of named building templates
- * (rectangles or polygon footprints) and a set of numbered layouts.
- * Layout keys are strings because YAML integer keys become string object
- * properties once loaded.
+ * (rectangles, polygon footprints, or curved path footprints) and a set
+ * of numbered layouts. Layout keys are strings because YAML integer keys
+ * become string object properties once loaded.
  */
 export type TerrainConfig = {
   templates: Record<string, Template>;

--- a/src/terrain-config.ts
+++ b/src/terrain-config.ts
@@ -6,9 +6,10 @@ export type TerrainLayout = {
 };
 
 /**
- * A terrain file as parsed from YAML: a set of named rectangle templates
- * and a set of numbered layouts. Layout keys are strings because YAML
- * integer keys become string object properties once loaded.
+ * A terrain file as parsed from YAML: a set of named building templates
+ * (rectangles or polygon footprints) and a set of numbered layouts.
+ * Layout keys are strings because YAML integer keys become string object
+ * properties once loaded.
  */
 export type TerrainConfig = {
   templates: Record<string, Template>;

--- a/src/terrain-config.ts
+++ b/src/terrain-config.ts
@@ -1,4 +1,4 @@
-import type { BuildingPlacement, RectTemplate } from "./building-coordinates";
+import type { BuildingPlacement, Template } from "./building-coordinates";
 
 /** One numbered layout: an ordered list of building placements. */
 export type TerrainLayout = {
@@ -11,7 +11,7 @@ export type TerrainLayout = {
  * integer keys become string object properties once loaded.
  */
 export type TerrainConfig = {
-  templates: Record<string, RectTemplate>;
+  templates: Record<string, Template>;
   layout: Record<string, TerrainLayout>;
 };
 

--- a/static/data/terrain/gw.yml
+++ b/static/data/terrain/gw.yml
@@ -1,17 +1,24 @@
 # Placeholder terrain layouts for the v2 building-coordinate schema.
-# These rectangles are illustrative, not official GW layouts — replace
-# them when transcribing real terrain.
+# These shapes are illustrative, not official GW layouts — replace them
+# when transcribing real terrain.
+#
+# A template is a rectangle (`width`/`height`) or a polygon footprint
+# (`points`: a closed ring of template-local [x, y] inches, bounding box
+# starting at 0,0). A polygon's width/height are derived from that bbox.
 #
 # Each building pins two of its corners (keyed by the building corner:
-# TL/TR/BL/BR) to inward distances from a canvas corner — by default the
-# canvas top-left. A building-level `from:` or a 3rd value inside a
-# corner selects a different canvas corner. Buildings are mirrored 180
-# degrees through the canvas centre unless `mirror: false`.
+# TL/TR/BL/BR — the template's bounding-box corners) to inward distances
+# from a canvas corner — by default the canvas top-left. A building-level
+# `from:` or a 3rd value inside a corner selects a different canvas
+# corner. Buildings are mirrored 180 degrees through the canvas centre
+# unless `mirror: false`.
 
 templates:
   4x6: { width: 4, height: 6 }
   6x12: { width: 6, height: 12 }
   5x10: { width: 5, height: 10 }
+  ruins-a:
+    points: [[1.5, 0], [4.5, 0.6], [5.5, 2.2], [7, 4.5], [5.8, 6.5], [6, 8.5], [4, 11], [2.5, 9.5], [2, 6.5], [0, 4], [1, 1.8]]
 
 layout:
   1:
@@ -22,6 +29,8 @@ layout:
         corners: { TL: [24, 4], TR: [28, 4] }
       - type: 5x10
         corners: { TL: [40, 8], TR: [45, 8] }
+      - type: ruins-a
+        corners: { TL: [22, 14], TR: [29, 14] }
   2:
     buildings:
       - type: 6x12

--- a/static/data/terrain/gw.yml
+++ b/static/data/terrain/gw.yml
@@ -2,9 +2,11 @@
 # These shapes are illustrative, not official GW layouts — replace them
 # when transcribing real terrain.
 #
-# A template is a rectangle (`width`/`height`) or a polygon footprint
+# A template is a rectangle (`width`/`height`), a polygon footprint
 # (`points`: a closed ring of template-local [x, y] inches, bounding box
-# starting at 0,0). A polygon's width/height are derived from that bbox.
+# starting at 0,0; width/height derived), or a curved path footprint
+# (`start` plus `segments` of line/quad/cubic Béziers, with a declared
+# `width`/`height` bounding box).
 #
 # Each building pins two of its corners (keyed by the building corner:
 # TL/TR/BL/BR — the template's bounding-box corners) to inward distances
@@ -19,6 +21,19 @@ templates:
   5x10: { width: 5, height: 10 }
   ruins-a:
     points: [[1.5, 0], [4.5, 0.6], [5.5, 2.2], [7, 4.5], [5.8, 6.5], [6, 8.5], [4, 11], [2.5, 9.5], [2, 6.5], [0, 4], [1, 1.8]]
+  curved-bastion:
+    width: 8
+    height: 8
+    start: [4, 0]
+    segments:
+      - cubic: [8, 4]
+        controls: [[6.21, 0], [8, 1.79]]
+      - cubic: [4, 8]
+        controls: [[8, 6.21], [6.21, 8]]
+      - cubic: [0, 4]
+        controls: [[1.79, 8], [0, 6.21]]
+      - cubic: [4, 0]
+        controls: [[0, 1.79], [1.79, 0]]
 
 layout:
   1:
@@ -37,3 +52,5 @@ layout:
         corners: { TL: [6, 10], TR: [12, 10] }
       - type: 4x6
         corners: { TL: [30, 8], TR: [34, 8] }
+      - type: curved-bastion
+        corners: { TL: [20, 24], TR: [28, 24] }


### PR DESCRIPTION
## Summary

Extends terrain building templates beyond rectangles with two new footprint kinds. All three kinds share the existing corner-pinning / rotation / 180°-mirroring placement math via `templateBounds` — only the rendered SVG shape differs.

- **Polygon templates** — a template can be an arbitrary single closed polygon (`points`: a ring of `[x,y]` board inches, bbox origin at `0,0`). Rendered as an SVG `<polygon>`; bounding box derived from the points.
- **Curved (path) templates** — a freeform template built from a structured `segments` list (line / quadratic Bézier / cubic Bézier) plus a `start` point and an author-declared `width`/`height` bounding box. Rendered as an SVG `<path>`.
- **Example data** — `ruins-a` (an irregular polygon) added to `gw.yml` layout 1; `curved-bastion` (a round footprint of four cubic Béziers) added to layout 2.

`templateBounds` validates each kind and throws on malformed templates; `terrain-config.ts` and `main.ts` needed only the widened `Template` union.

## Test Plan

- [ ] `pnpm test` — 70 tests pass (polygon + path `templateBounds`, `resolveBuilding` placement, `segmentsToPathData`, `<polygon>`/`<path>` def emission)
- [ ] `pnpm type-check`, `pnpm lint`, `pnpm build` all clean
- [ ] GW Layout 1 renders the `ruins-a` polygon footprint (primary + 180° mirror)
- [ ] GW Layout 2 renders the smooth `curved-bastion` footprint (primary + 180° mirror)

🤖 Generated with [Claude Code](https://claude.com/claude-code)