### PR TITLE
Render objectives; dedupe editor coords, drag, and mission lists

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1113,18 +1113,6 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
-  tinyglobby@0.2.17:
-    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
-    engines: {node: '>=12.0.0'}
-
-  tinyglobby@0.2.17:
-    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
-    engines: {node: '>=12.0.0'}
-
-  tinyglobby@0.2.17:
-    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
-    engines: {node: '>=12.0.0'}
-
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
@@ -2259,21 +2247,6 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
-
-  tinyglobby@0.2.17:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
-  tinyglobby@0.2.17:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
-  tinyglobby@0.2.17:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.17:
     dependencies:

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -8,7 +8,11 @@ const isWatch = process.env.ROLLUP_WATCH === "true";
 
 export default [
   {
-    input: "src/main.ts",
+    // index.ts is the package's public entry: it re-exports the renderer plus
+    // the generated presets (missions, gwTerrain), which static/app.js needs
+    // for its dropdowns. Keeping the web bundle on index.ts is what lets the
+    // mission/layout lists live in one place (the YAML-generated presets).
+    input: "src/index.ts",
     output: { file: "dist/bundle.js", format: "es" },
     treeshake: false,
     plugins: [

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -318,7 +318,7 @@ async function fetchYaml(url: string): Promise<unknown> {
 }
 
 let overlaySvg: SVGSVGElement | null = null;
-const sel: SelectionState = { selectedId: null, vertexEditId: null, dragVertexIndex: null };
+const sel: SelectionState = { selectedId: null, vertexEditId: null };
 
 function initPalette(): void {
   const items = buildPaletteItems(loadedTemplates);
@@ -341,11 +341,6 @@ function initPalette(): void {
     scheduleRender();
   });
 }
-
-// Exported for read-access by other editor modules.
-// Mutate via: scene.objects.push/splice/etc. (in-place mutation on the scene object itself).
-// Do NOT try to reassign the exported binding from another module — use scheduleRender() after any mutation.
-export { scene, loadedTemplates, snapEnabled, overlaySvg, fetchYaml };
 
 async function start(): Promise<void> {
   try {

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -123,24 +123,27 @@ function updateStatus(): void {
   }
 }
 
-function liveMapCoords(ev: PointerEvent): { x: number; y: number } {
+/**
+ * Converts client (screen) coordinates to board inches via the live map SVG.
+ * Accepts anything with clientX/clientY, so both PointerEvent and DragEvent
+ * (palette drop) share one conversion. Returns (0,0) when no map is rendered.
+ */
+function mapCoords(clientX: number, clientY: number): { x: number; y: number } {
   const mapSvg = canvasWrap.querySelector<SVGSVGElement>("svg.map-svg");
   if (!mapSvg) return { x: 0, y: 0 };
   const rect = mapSvg.getBoundingClientRect();
   return {
-    x: ((ev.clientX - rect.left) / rect.width) * scene.boardWidth,
-    y: ((ev.clientY - rect.top) / rect.height) * scene.boardHeight,
+    x: ((clientX - rect.left) / rect.width) * scene.boardWidth,
+    y: ((clientY - rect.top) / rect.height) * scene.boardHeight,
   };
 }
 
 function attachOverlayEvents(svg: SVGSVGElement): void {
   svg.addEventListener("pointermove", (e) => {
-    const mapSvg = canvasWrap.querySelector<SVGSVGElement>("svg.map-svg");
-    if (!mapSvg) return;
-    const rect = mapSvg.getBoundingClientRect();
-    const x = (((e.clientX - rect.left) / rect.width) * scene.boardWidth).toFixed(1);
-    const y = (((e.clientY - rect.top) / rect.height) * scene.boardHeight).toFixed(1);
-    document.getElementById("status-cursor")!.textContent = `cursor: ${x}″, ${y}″`;
+    if (!canvasWrap.querySelector("svg.map-svg")) return;
+    const { x, y } = mapCoords(e.clientX, e.clientY);
+    document.getElementById("status-cursor")!.textContent =
+      `cursor: ${x.toFixed(1)}″, ${y.toFixed(1)}″`;
   });
 
   svg.addEventListener("pointerdown", (e) => {
@@ -216,48 +219,59 @@ function attachOverlayEvents(svg: SVGSVGElement): void {
   });
 }
 
+/**
+ * Captures the pointer and runs a drag loop: `onMove` fires for every
+ * pointermove until pointerup/pointercancel, then `onEnd` runs once and the
+ * listeners are torn down. No-ops when no map is rendered. Returns whether
+ * the drag actually started, so callers can skip per-drag setup.
+ */
+function startDragLoop(
+  e: PointerEvent,
+  onMove: (ev: PointerEvent) => void,
+  onEnd?: () => void,
+): void {
+  if (!canvasWrap.querySelector("svg.map-svg")) return;
+  canvasWrap.setPointerCapture(e.pointerId);
+  const up = () => {
+    window.removeEventListener("pointermove", onMove);
+    window.removeEventListener("pointerup", up);
+    window.removeEventListener("pointercancel", up);
+    onEnd?.();
+  };
+  window.addEventListener("pointermove", onMove);
+  window.addEventListener("pointerup", up);
+  window.addEventListener("pointercancel", up);
+}
+
+const snap = (v: number) => (snapEnabled ? Math.round(v) : v);
+
 function startDrag(e: PointerEvent, id: string): void {
   const obj = scene.objects.find((o) => o.id === id);
   if (!obj) return;
-  if (!canvasWrap.querySelector<SVGSVGElement>("svg.map-svg")) return;
-
-  canvasWrap.setPointerCapture(e.pointerId);
-
-  const snap = (v: number) => (snapEnabled ? Math.round(v) : v);
-  const start = liveMapCoords(e);
+  const start = mapCoords(e.clientX, e.clientY);
   const origX = obj.x;
   const origY = obj.y;
 
-  function onMove(ev: PointerEvent) {
-    const pos = liveMapCoords(ev);
-    const idx = scene.objects.findIndex((o) => o.id === id);
-    if (idx >= 0) {
-      scene.objects[idx] = {
-        ...scene.objects[idx],
-        x: snap(origX + pos.x - start.x),
-        y: snap(origY + pos.y - start.y),
-      } as typeof scene.objects[number];
-      scheduleRender();
-    }
-  }
-  function onUp() {
-    window.removeEventListener("pointermove", onMove);
-    window.removeEventListener("pointerup", onUp);
-    window.removeEventListener("pointercancel", onUp);
-    updateInspector();
-  }
-  window.addEventListener("pointermove", onMove);
-  window.addEventListener("pointerup", onUp);
-  window.addEventListener("pointercancel", onUp);
+  startDragLoop(
+    e,
+    (ev) => {
+      const pos = mapCoords(ev.clientX, ev.clientY);
+      const idx = scene.objects.findIndex((o) => o.id === id);
+      if (idx >= 0) {
+        scene.objects[idx] = {
+          ...scene.objects[idx],
+          x: snap(origX + pos.x - start.x),
+          y: snap(origY + pos.y - start.y),
+        } as typeof scene.objects[number];
+        scheduleRender();
+      }
+    },
+    updateInspector,
+  );
 }
 function startVertexDrag(e: PointerEvent, id: string, vi: number): void {
-  if (!canvasWrap.querySelector<SVGSVGElement>("svg.map-svg")) return;
-  const snap = (v: number) => (snapEnabled ? Math.round(v) : v);
-
-  canvasWrap.setPointerCapture(e.pointerId);
-
-  const onMove = (ev: PointerEvent) => {
-    const { x: px, y: py } = liveMapCoords(ev);
+  startDragLoop(e, (ev) => {
+    const { x: px, y: py } = mapCoords(ev.clientX, ev.clientY);
     const snappedX = snap(px);
     const snappedY = snap(py);
     const idx = scene.objects.findIndex((o) => o.id === id);
@@ -269,46 +283,30 @@ function startVertexDrag(e: PointerEvent, id: string, vi: number): void {
       vertices: obj.vertices.map((v, i) => (i === vi ? [snappedX, snappedY] as [number, number] : v)),
     };
     scheduleRender();
-  };
-  const onUp = () => {
-    window.removeEventListener("pointermove", onMove);
-    window.removeEventListener("pointerup", onUp);
-    window.removeEventListener("pointercancel", onUp);
-  };
-  window.addEventListener("pointermove", onMove);
-  window.addEventListener("pointerup", onUp);
-  window.addEventListener("pointercancel", onUp);
+  });
 }
 function startRotateDrag(e: PointerEvent, id: string): void {
   const obj = scene.objects.find((o) => o.id === id);
   if (!obj) return;
-  if (!canvasWrap.querySelector<SVGSVGElement>("svg.map-svg")) return;
   const center = objectCenter(obj, loadedTemplates);
 
-  canvasWrap.setPointerCapture(e.pointerId);
-
   const getAngle = (ev: PointerEvent): number => {
-    const { x: px, y: py } = liveMapCoords(ev);
+    const { x: px, y: py } = mapCoords(ev.clientX, ev.clientY);
     const raw = Math.atan2(py - center.y, px - center.x) * (180 / Math.PI) + 90;
     return ((raw % 360) + 360) % 360;
-  }
+  };
 
-  function onMove(ev: PointerEvent) {
-    const idx = scene.objects.findIndex((o) => o.id === id);
-    if (idx >= 0) {
-      scene.objects[idx] = { ...scene.objects[idx], rotation: getAngle(ev) } as typeof scene.objects[number];
-      scheduleRender();
-    }
-  }
-  function onUp() {
-    window.removeEventListener("pointermove", onMove);
-    window.removeEventListener("pointerup", onUp);
-    window.removeEventListener("pointercancel", onUp);
-    updateInspector();
-  }
-  window.addEventListener("pointermove", onMove);
-  window.addEventListener("pointerup", onUp);
-  window.addEventListener("pointercancel", onUp);
+  startDragLoop(
+    e,
+    (ev) => {
+      const idx = scene.objects.findIndex((o) => o.id === id);
+      if (idx >= 0) {
+        scene.objects[idx] = { ...scene.objects[idx], rotation: getAngle(ev) } as typeof scene.objects[number];
+        scheduleRender();
+      }
+    },
+    updateInspector,
+  );
 }
 
 async function fetchYaml(url: string): Promise<unknown> {
@@ -332,11 +330,8 @@ function initPalette(): void {
     const raw = e.dataTransfer?.getData("text/plain");
     if (!raw) return;
     const item = JSON.parse(raw) as PaletteItem;
-    const mapSvg = canvasWrap.querySelector<SVGSVGElement>("svg.map-svg");
-    if (!mapSvg) return;
-    const rect = mapSvg.getBoundingClientRect();
-    const svgX = ((e.clientX - rect.left) / rect.width) * scene.boardWidth;
-    const svgY = ((e.clientY - rect.top) / rect.height) * scene.boardHeight;
+    if (!canvasWrap.querySelector("svg.map-svg")) return;
+    const { x: svgX, y: svgY } = mapCoords(e.clientX, e.clientY);
     scene.objects.push(createObjectFromPalette(item, svgX, svgY, scene));
     scheduleRender();
   });

--- a/src/editor/overlay.ts
+++ b/src/editor/overlay.ts
@@ -1,5 +1,6 @@
 import { templateBounds } from "../building-coordinates.js";
 import type { Template } from "../building-coordinates.js";
+import { DEFAULT_AREA_TERRAIN_SIZE } from "../terrain-config.js";
 import type { Scene, SceneObject, DeploymentZoneObject } from "./scene.js";
 
 export type SelectionState = {
@@ -17,7 +18,12 @@ export function objectBounds(
     return { x: obj.x, y: obj.y, w: size.width, h: size.height };
   }
   if (obj.type === "area-terrain") {
-    return { x: obj.x, y: obj.y, w: obj.width ?? 6, h: obj.height ?? obj.width ?? 6 };
+    return {
+      x: obj.x,
+      y: obj.y,
+      w: obj.width ?? DEFAULT_AREA_TERRAIN_SIZE,
+      h: obj.height ?? obj.width ?? DEFAULT_AREA_TERRAIN_SIZE,
+    };
   }
   if (obj.type === "objective") {
     return { x: obj.x - 1.5, y: obj.y - 1.5, w: 3, h: 3 };

--- a/src/editor/overlay.ts
+++ b/src/editor/overlay.ts
@@ -5,7 +5,6 @@ import type { Scene, SceneObject, DeploymentZoneObject } from "./scene.js";
 export type SelectionState = {
   selectedId: string | null;
   vertexEditId: string | null;
-  dragVertexIndex: number | null;
 };
 
 export function objectBounds(

--- a/src/editor/palette.ts
+++ b/src/editor/palette.ts
@@ -1,4 +1,5 @@
 import type { Template } from "../building-coordinates.js";
+import { DEFAULT_AREA_TERRAIN_SIZE } from "../terrain-config.js";
 import type { Scene, SceneObject, ObjectiveObject } from "./scene.js";
 
 export type PaletteItem =
@@ -98,7 +99,11 @@ export function createObjectFromPalette(
     return { id, type: "building", templateKey: item.templateKey, x, y, rotation: 0, mirror: true };
   }
   if (item.category === "area-terrain") {
-    return { id, type: "area-terrain", shape: item.shape, x, y, rotation: 0, width: 6, height: 6, label: item.label };
+    return {
+      id, type: "area-terrain", shape: item.shape, x, y, rotation: 0,
+      width: DEFAULT_AREA_TERRAIN_SIZE, height: DEFAULT_AREA_TERRAIN_SIZE,
+      label: item.label,
+    };
   }
   if (item.category === "objective") {
     const used = new Set(

--- a/src/editor/presets.ts
+++ b/src/editor/presets.ts
@@ -1,20 +1,20 @@
 import { resolveBuilding } from "../building-coordinates.js";
 import type { Template, BuildingPlacement } from "../building-coordinates.js";
+import { missions } from "../presets/missions.js";
+import { gwTerrain } from "../presets/terrain.js";
 import type { Scene, SceneObject } from "./scene.js";
 
-export const MISSIONS = [
-  { id: "dawn_of_war", label: "Dawn of War" },
-  { id: "crucible_of_battle", label: "Crucible of Battle" },
-  { id: "hammer_and_anvil", label: "Hammer and Anvil" },
-  { id: "search_and_destroy", label: "Search and Destroy" },
-  { id: "sweeping_engagement", label: "Sweeping Engagement" },
-  { id: "tipping_point", label: "Tipping Point" },
-];
+// Derived from the generated presets so the mission/layout lists can never
+// drift from the YAML they come from (see scripts/gen-presets.mjs).
+export const MISSIONS = Object.entries(missions).map(([id, m]) => ({
+  id,
+  label: m.name,
+}));
 
-export const TERRAIN_LAYOUTS = [
-  { id: "1", label: "GW Layout 1" },
-  { id: "2", label: "GW Layout 2" },
-];
+export const TERRAIN_LAYOUTS = Object.keys(gwTerrain.layout).map((id) => ({
+  id,
+  label: `GW Layout ${id}`,
+}));
 
 type MissionYaml = {
   name: string;

--- a/src/editor/scene.ts
+++ b/src/editor/scene.ts
@@ -1,6 +1,12 @@
 import { templateBounds, type BuildingPlacement } from "../building-coordinates.js";
 import type { AreaTerrain } from "../terrain-config.js";
-import type { Annotation, BaseConfig, DeploymentConfig, FullConfig } from "../types.js";
+import type {
+  Annotation,
+  BaseConfig,
+  DeploymentConfig,
+  FullConfig,
+  Objective,
+} from "../types.js";
 import type { Template } from "../building-coordinates.js";
 
 export type SceneObjectBase = {
@@ -164,9 +170,9 @@ export function sceneToConfig(
       endY: o.endY,
     }));
 
-  // Objectives are not mapped to FullConfig — the renderer has no objectives
-  // field since the 11th-edition objective marker system was removed.
-  // ObjectiveObject exists in the scene model for future editor use.
+  const objectiveItems: Objective[] = scene.objects
+    .filter((o): o is ObjectiveObject => o.type === "objective")
+    .map((o) => ({ x: o.x, y: o.y, number: o.number }));
 
   const deployment: DeploymentConfig = {
     name: scene.missionName,
@@ -193,6 +199,7 @@ export function sceneToConfig(
       layout_name: "editor",
       ...(areaTerrainItems.length > 0 && { area_terrain: areaTerrainItems }),
     },
+    ...(objectiveItems.length > 0 && { objectives: objectiveItems }),
     ...(annotationItems.length > 0 && { annotations: annotationItems }),
   };
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -209,6 +209,30 @@ describe("makeAnnotations", () => {
   });
 });
 
+describe("makeObjectives", () => {
+  it("renders a numbered marker per objective", () => {
+    const cfg = buildMinimalConfig();
+    cfg.objectives = [
+      { x: 30, y: 22, number: 1 },
+      { x: 15, y: 10, number: 2 },
+    ];
+    const svg = makeMissionCard(cfg);
+    const markers = svg.querySelectorAll("#objectives circle");
+    expect(markers.length).toBe(2);
+    expect(markers[0].getAttribute("cx")).toBe("30");
+    expect(markers[0].getAttribute("cy")).toBe("22");
+    const labels = svg.querySelectorAll("#objectives text");
+    expect(labels.length).toBe(2);
+    expect([...labels].map((t) => t.textContent)).toEqual(["1", "2"]);
+  });
+
+  it("skips the objectives group when config has no objectives", () => {
+    const cfg = buildMinimalConfig();
+    const svg = makeMissionCard(cfg);
+    expect(svg.querySelector("#objectives")).toBeNull();
+  });
+});
+
 describe("makeDeploymentZone rendering", () => {
   it("renders a polygon when mask_center is absent", () => {
     const config = buildMinimalConfig();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { injectTemplateDefs, makeBuildings } from "./buildings.js";
 import { applyAttributes, makeElement } from "./dom-helpers.js";
-import { getLayoutBuildings } from "./terrain-config.js";
+import { DEFAULT_AREA_TERRAIN_SIZE, getLayoutBuildings } from "./terrain-config.js";
 import type { FullConfig } from "./types.js";
 
 /** True when a usable layout is selected in the terrain config. */
@@ -147,7 +147,7 @@ function makeAreaTerrain(config: FullConfig): SVGElement | null {
       AREA_TERRAIN_STYLES[item.label ?? ""] ?? DEFAULT_AREA_TERRAIN_STYLE;
     let shape: SVGElement;
     if (item.shape === "circle") {
-      const r = (item.width ?? 4) / 2;
+      const r = (item.width ?? DEFAULT_AREA_TERRAIN_SIZE) / 2;
       shape = makeElement("circle");
       shape.setAttribute("cx", `${item.x + r}`);
       shape.setAttribute("cy", `${item.y + r}`);
@@ -163,11 +163,43 @@ function makeAreaTerrain(config: FullConfig): SVGElement | null {
     shape.setAttribute("stroke", style.stroke);
     shape.setAttribute("stroke-width", "0.3");
     if (item.rotation) {
-      const cx = item.x + (item.width ?? 4) / 2;
-      const cy = item.y + (item.height ?? item.width ?? 4) / 2;
+      const cx = item.x + (item.width ?? DEFAULT_AREA_TERRAIN_SIZE) / 2;
+      const cy =
+        item.y + (item.height ?? item.width ?? DEFAULT_AREA_TERRAIN_SIZE) / 2;
       shape.setAttribute("transform", `rotate(${item.rotation} ${cx} ${cy})`);
     }
     group.appendChild(shape);
+  }
+  return group;
+}
+
+/** Numbered objective markers sit on top of zones, terrain, and buildings. */
+const OBJECTIVE_RADIUS = 1.5;
+
+function makeObjectives(config: FullConfig): SVGElement | null {
+  const items = config.objectives;
+  if (!items || items.length === 0) return null;
+  const group = makeElement("g");
+  group.setAttribute("id", "objectives");
+  for (const item of items) {
+    const marker = makeElement("circle");
+    marker.setAttribute("cx", `${item.x}`);
+    marker.setAttribute("cy", `${item.y}`);
+    marker.setAttribute("r", `${OBJECTIVE_RADIUS}`);
+    marker.setAttribute("fill", "#1a1a1a");
+    marker.setAttribute("stroke", "white");
+    marker.setAttribute("stroke-width", "0.3");
+    group.appendChild(marker);
+
+    const label = makeElement("text");
+    label.setAttribute("x", `${item.x}`);
+    label.setAttribute("y", `${item.y}`);
+    label.setAttribute("text-anchor", "middle");
+    label.setAttribute("dominant-baseline", "central");
+    label.setAttribute("font-size", "2");
+    label.setAttribute("fill", "white");
+    label.textContent = `${item.number}`;
+    group.appendChild(label);
   }
   return group;
 }
@@ -271,6 +303,11 @@ export function makeMissionCard(config: FullConfig): SVGElement {
     const empty = makeElement("g");
     empty.setAttribute("id", "buildings");
     svg.appendChild(empty);
+  }
+
+  const objectives = makeObjectives(config);
+  if (objectives) {
+    svg.appendChild(objectives);
   }
 
   const annotations = makeAnnotations(config);

--- a/src/terrain-config.ts
+++ b/src/terrain-config.ts
@@ -1,5 +1,13 @@
 import type { BuildingPlacement, Template } from "./building-coordinates.js";
 
+/**
+ * Default width/height (inches) for area terrain placed without an explicit
+ * size. Shared by the renderer (`main.ts`) and the editor (overlay/palette)
+ * so a piece dropped at the default size renders at the size its handle box
+ * showed.
+ */
+export const DEFAULT_AREA_TERRAIN_SIZE = 6;
+
 export type AreaTerrain = {
   shape: "circle" | "polygon";
   x: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,13 +7,11 @@ export type Size = { width: number; height: number };
 
 export type DrawAndProperties = {
   draw?: boolean;
-  radius?: number;
   svg_properties: SVGProperties;
 };
 
-export type Attacker = { svg_properties: SVGProperties };
-export type Defender = { svg_properties: SVGProperties };
-export type BaseDeployment = { attacker: Attacker; defender: Defender };
+export type DeploymentSide = { svg_properties: SVGProperties };
+export type BaseDeployment = { attacker: DeploymentSide; defender: DeploymentSide };
 
 export type Building = {
   draw: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,10 +57,18 @@ export type Annotation = {
   endY?: number;
 };
 
+/** A numbered objective marker, positioned by its center in inches. */
+export type Objective = {
+  x: number;
+  y: number;
+  number: number;
+};
+
 /** The whole config object built by static/index.html. */
 export type FullConfig = {
   base: BaseConfig;
   terrain: RuntimeTerrainConfig;
   deployment: DeploymentConfig;
+  objectives?: Objective[];
   annotations?: Annotation[];
 };

--- a/static/app.js
+++ b/static/app.js
@@ -1,5 +1,5 @@
 /* global jsyaml */
-import { makeMissionCard } from "./bundle.js";
+import { makeMissionCard, missions, gwTerrain } from "./bundle.js";
 import {
   DEFAULT_CONTROLS,
   clearUrl,
@@ -11,21 +11,19 @@ import {
   writeControlsToUrl,
 } from "./state.js";
 
-// Single source of truth for the dropdowns: both the <select> options and
-// the persistence allowlists are derived from these lists, so the two can
-// never drift apart. Each id is also the YAML filename / layout key.
-const MISSIONS = [
-  { id: "dawn_of_war", label: "Dawn of War" },
-  { id: "crucible_of_battle", label: "Crucible of Battle" },
-  { id: "hammer_and_anvil", label: "Hammer and Anvil" },
-  { id: "search_and_destroy", label: "Search and Destroy" },
-  { id: "sweeping_engagement", label: "Sweeping Engagement" },
-  { id: "tipping_point", label: "Tipping Point" },
-];
-const TERRAINS = [
-  { id: "1", label: "GW Layout 1" },
-  { id: "2", label: "GW Layout 2" },
-];
+// Dropdown options derive from the generated presets in the bundle, which are
+// generated from the YAML (see scripts/gen-presets.mjs). The persistence
+// allowlists derive from these in turn, so options, allowlists, and the
+// underlying YAML can never drift apart. Each id is also the YAML filename /
+// layout key. Mission labels are the deployment `name`.
+const MISSIONS = Object.entries(missions).map(([id, m]) => ({
+  id,
+  label: m.name,
+}));
+const TERRAINS = Object.keys(gwTerrain.layout).map((id) => ({
+  id,
+  label: `GW Layout ${id}`,
+}));
 const MISSION_IDS = MISSIONS.map((m) => m.id);
 const TERRAIN_IDS = TERRAINS.map((t) => t.id);
 


### PR DESCRIPTION
Addresses the remaining items from the codebase review.

## Changes

**Objectives now render (#4).** Objectives placed in the editor were silently dropped on render/export. Added an `objectives` field to `FullConfig` and a `makeObjectives` renderer (numbered markers, layered above buildings / below annotations), and mapped editor objective objects through `sceneToConfig`.

**Coordinate-math dedup (#5).** The three inline screen→board conversions in `editor.ts` now go through one `mapCoords(clientX, clientY)` helper, generalized so the palette-drop `DragEvent` shares it with `PointerEvent`.

**Drag boilerplate extracted (#6).** The pointer-capture + move/up/cancel listener dance is now a single `startDragLoop(e, onMove, onEnd?)`; `startDrag` / `startVertexDrag` / `startRotateDrag` collapse onto it.

**Triplicated mission lists → one source (#7).** The editor and the browser app now derive their mission/layout dropdowns from the YAML-generated presets. The web bundle entry moved from `src/main.ts` to `src/index.ts` (the public entry, which already re-exports the presets) so `app.js` can import them. Visible effect: dropdowns are now alphabetical by id; default selection unaffected.

**Area-terrain default size unified (#9).** New `DEFAULT_AREA_TERRAIN_SIZE = 6` in `terrain-config.ts`; the renderer (previously defaulted to 4), overlay, and palette all use it, so a default-size piece renders at the size its editor handle box shows.

**Docs.** Updated the architecture notes: corrected render order, removed gone `objectives.ts` / `coordinates.ts` / center-mask references, documented the editor app, generated presets, and new bundle entry.

## Testing

- `gen:presets:check`, `type-check`, `lint`, `test` (96 passing, +2 for objectives), and `build` all green.
- Live browser smoke test of both apps: objective render at drop point, object drag (moved exactly the expected distance), and the derived dropdowns.