### PR TITLE
Terrain icon markers (skull/fortress) with player-coloured disks

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -19,7 +19,10 @@ export default [
       tsPlugin(),
       copy({ targets: [] }),
       ...(isWatch
-        ? [serve({ contentBase: ["dist", "static", "samples"], open: true }), autoReload()]
+        ? // Serve live sources first so a prior `make build-gh-pages` copy of
+          // static/* into dist/ can't shadow edits during dev. dist still
+          // provides the built bundle.js / editor.bundle.js (absent from static).
+          [serve({ contentBase: ["static", "samples", "dist"], open: true }), autoReload()]
         : []),
     ],
   },

--- a/src/building-coordinates.test.ts
+++ b/src/building-coordinates.test.ts
@@ -102,6 +102,85 @@ describe("resolveBuilding (single, non-mirrored)", () => {
   });
 });
 
+describe("resolveBuilding (single corner)", () => {
+  it("pins a single TL corner with no rotation", () => {
+    const result = resolveBuilding(
+      { type: "4x6", mirror: false, corners: { TL: [10, 5] } },
+      templates,
+      canvas,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].templateName).toBe("4x6");
+    expect(result[0].translate[0]).toBeCloseTo(10);
+    expect(result[0].translate[1]).toBeCloseTo(5);
+    expect(result[0].rotation).toBeCloseTo(0);
+  });
+
+  it("pins a single TR corner (translate offset by the template width)", () => {
+    // building TR corner -> canvas point (10,5); localCorner(TR)=(4,0)
+    const result = resolveBuilding(
+      { type: "4x6", mirror: false, corners: { TR: [10, 5] } },
+      templates,
+      canvas,
+    );
+    expect(result[0].translate[0]).toBeCloseTo(6);
+    expect(result[0].translate[1]).toBeCloseTo(5);
+    expect(result[0].rotation).toBeCloseTo(0);
+  });
+
+  it("pins a single BL corner (translate offset by the template height)", () => {
+    // building BL corner -> canvas point (10,5); localCorner(BL)=(0,6)
+    const result = resolveBuilding(
+      { type: "4x6", mirror: false, corners: { BL: [10, 5] } },
+      templates,
+      canvas,
+    );
+    expect(result[0].translate[0]).toBeCloseTo(10);
+    expect(result[0].translate[1]).toBeCloseTo(-1);
+    expect(result[0].rotation).toBeCloseTo(0);
+  });
+
+  it("pins a single BR corner (offset by width and height)", () => {
+    // building BR corner -> canvas point (10,5); localCorner(BR)=(4,6)
+    const result = resolveBuilding(
+      { type: "4x6", mirror: false, corners: { BR: [10, 5] } },
+      templates,
+      canvas,
+    );
+    expect(result[0].translate[0]).toBeCloseTo(6);
+    expect(result[0].translate[1]).toBeCloseTo(-1);
+    expect(result[0].rotation).toBeCloseTo(0);
+  });
+
+  it("honours the canvas anchor for a single corner", () => {
+    // building TL corner -> (10,5) from canvas TR = (60-10, 5) = (50,5)
+    const result = resolveBuilding(
+      { type: "4x6", mirror: false, corners: { TL: [10, 5, "TR"] } },
+      templates,
+      canvas,
+    );
+    expect(result[0].translate[0]).toBeCloseTo(50);
+    expect(result[0].translate[1]).toBeCloseTo(5);
+    expect(result[0].rotation).toBeCloseTo(0);
+  });
+
+  it("mirrors a single corner by default (mirror at rotation 180)", () => {
+    const result = resolveBuilding(
+      { type: "4x6", corners: { TL: [10, 5] } },
+      templates,
+      canvas,
+    );
+    expect(result).toHaveLength(2);
+    const [primary, mirrored] = result;
+    expect(primary.translate[0]).toBeCloseTo(10);
+    expect(primary.translate[1]).toBeCloseTo(5);
+    expect(primary.rotation).toBeCloseTo(0);
+    expect(mirrored.translate[0]).toBeCloseTo(50);
+    expect(mirrored.translate[1]).toBeCloseTo(39);
+    expect(mirrored.rotation).toBeCloseTo(180);
+  });
+});
+
 describe("resolveBuilding mirroring", () => {
   it("emits a 180-degree point-reflected copy by default", () => {
     const result = resolveBuilding(
@@ -150,14 +229,20 @@ describe("resolveBuilding validation", () => {
     ).toThrow(/unknown template/i);
   });
 
-  it("throws when there are not exactly 2 corners", () => {
+  it("throws when there are no corners", () => {
+    expect(() =>
+      resolveBuilding({ type: "4x6", corners: {} }, templates, canvas),
+    ).toThrow(/1 or 2 corners/i);
+  });
+
+  it("throws when there are more than 2 corners", () => {
     expect(() =>
       resolveBuilding(
-        { type: "4x6", corners: { TL: [10, 5] } },
+        { type: "4x6", corners: { TL: [10, 5], TR: [14, 5], BR: [14, 11] } },
         templates,
         canvas,
       ),
-    ).toThrow(/exactly 2 corners/i);
+    ).toThrow(/1 or 2 corners/i);
   });
 
   it("throws when the corner distance disagrees with the template edge", () => {

--- a/src/building-coordinates.ts
+++ b/src/building-coordinates.ts
@@ -122,7 +122,7 @@ export function templateBounds(
 
 export type BuildingPlacement = {
   type: string;
-  corners: Partial<Record<Anchor, CornerSpec>>; // exactly 2 entries
+  corners: Partial<Record<Anchor, CornerSpec>>; // 1 or 2 entries
   from?: Anchor; // default anchor for 2-element corner specs; default "TL"
   mirror?: boolean; // default true
 };
@@ -175,33 +175,40 @@ export function resolveBuilding(
     );
   }
   const entries = Object.entries(placement.corners) as [Anchor, CornerSpec][];
-  if (entries.length !== 2) {
+  if (entries.length < 1 || entries.length > 2) {
     throw new Error(
-      `building ${placement.type}: expected exactly 2 corners, got ${entries.length}`,
+      `building ${placement.type}: expected 1 or 2 corners, got ${entries.length}`,
     );
   }
   const defaultFrom: Anchor = placement.from ?? "TL";
-
-  const [[cornerA, specA], [cornerB, specB]] = entries;
-  const pA = resolveCorner(specA, defaultFrom, canvas);
-  const pB = resolveCorner(specB, defaultFrom, canvas);
   const size = templateBounds(template, placement.type);
+
+  const [[cornerA, specA]] = entries;
+  const pA = resolveCorner(specA, defaultFrom, canvas);
   const lA = localCorner(cornerA, size);
-  const lB = localCorner(cornerB, size);
 
-  const targetLength = Math.hypot(pB[0] - pA[0], pB[1] - pA[1]);
-  const templateLength = Math.hypot(lB[0] - lA[0], lB[1] - lA[1]);
-  if (Math.abs(targetLength - templateLength) > 0.1) {
-    throw new Error(
-      `building ${placement.type}: corners ${cornerA}->${cornerB} measure ` +
-        `${targetLength.toFixed(1)}" apart but template edge is ` +
-        `${templateLength.toFixed(1)}"`,
-    );
+  // A single corner pins position with no rotation; a second corner derives
+  // the rotation (and is checked against the template's edge length).
+  let theta = 0;
+  if (entries.length === 2) {
+    const [, [cornerB, specB]] = entries;
+    const pB = resolveCorner(specB, defaultFrom, canvas);
+    const lB = localCorner(cornerB, size);
+
+    const targetLength = Math.hypot(pB[0] - pA[0], pB[1] - pA[1]);
+    const templateLength = Math.hypot(lB[0] - lA[0], lB[1] - lA[1]);
+    if (Math.abs(targetLength - templateLength) > 0.1) {
+      throw new Error(
+        `building ${placement.type}: corners ${cornerA}->${cornerB} measure ` +
+          `${targetLength.toFixed(1)}" apart but template edge is ` +
+          `${templateLength.toFixed(1)}"`,
+      );
+    }
+
+    theta =
+      Math.atan2(pB[1] - pA[1], pB[0] - pA[0]) -
+      Math.atan2(lB[1] - lA[1], lB[0] - lA[0]);
   }
-
-  const theta =
-    Math.atan2(pB[1] - pA[1], pB[0] - pA[0]) -
-    Math.atan2(lB[1] - lA[1], lB[0] - lA[0]);
   const rotatedLA = rotate(lA, theta);
   const translate: Point = [pA[0] - rotatedLA[0], pA[1] - rotatedLA[1]];
   const rotation = (((theta * 180) / Math.PI) % 360 + 360) % 360;

--- a/src/editor/inspector.ts
+++ b/src/editor/inspector.ts
@@ -183,6 +183,31 @@ export function renderInspector(
     bodyEl.appendChild(txtField);
   }
 
+  if (obj.type === "icon") {
+    const { wrap: pField } = makeField("Player colour");
+    const sel = document.createElement("select");
+    sel.className = "field-input field-select";
+    const playerOptions: { value: string; label: string }[] = [
+      { value: "", label: "None" },
+      { value: "attacker", label: "Attacker" },
+      { value: "defender", label: "Defender" },
+    ];
+    for (const o of playerOptions) {
+      const opt = document.createElement("option");
+      opt.value = o.value;
+      opt.textContent = o.label;
+      if ((obj.player ?? "") === o.value) opt.selected = true;
+      sel.appendChild(opt);
+    }
+    sel.addEventListener("change", () =>
+      onChange(obj.id, {
+        player: sel.value === "" ? undefined : (sel.value as "attacker" | "defender"),
+      } as Partial<SceneObject>),
+    );
+    pField.appendChild(sel);
+    bodyEl.appendChild(pField);
+  }
+
   const delBtn = document.createElement("button");
   delBtn.className = "del-btn";
   delBtn.textContent = "Delete Object";

--- a/src/editor/inspector.ts
+++ b/src/editor/inspector.ts
@@ -11,6 +11,7 @@ const CHIP_LABELS: Record<string, string> = {
   objective: "OBJECTIVE",
   "deployment-zone": "DEPLOY ZONE",
   annotation: "ANNOTATION",
+  icon: "ICON",
 };
 
 function numInput(value: number, onchange: (v: number) => void): HTMLInputElement {

--- a/src/editor/overlay.ts
+++ b/src/editor/overlay.ts
@@ -1,6 +1,7 @@
 import { templateBounds } from "../building-coordinates.js";
 import type { Template } from "../building-coordinates.js";
 import { DEFAULT_AREA_TERRAIN_SIZE } from "../terrain-config.js";
+import { ICON_SIZE } from "../icons.js";
 import type { Scene, SceneObject, DeploymentZoneObject } from "./scene.js";
 
 export type SelectionState = {
@@ -34,6 +35,9 @@ export function objectBounds(
     const ys = obj.vertices.map(([, vy]) => vy);
     const x = Math.min(...xs), y = Math.min(...ys);
     return { x, y, w: Math.max(...xs) - x, h: Math.max(...ys) - y };
+  }
+  if (obj.type === "icon") {
+    return { x: obj.x, y: obj.y, w: ICON_SIZE, h: ICON_SIZE };
   }
   return { x: obj.x - 1, y: obj.y - 1, w: 8, h: 3 };
 }
@@ -145,26 +149,28 @@ export function renderOverlay(
       box.style.pointerEvents = "none";
       wrapper.appendChild(box);
 
-      const cx = b.x + b.w / 2;
-      const stem = svgEl("line");
-      stem.setAttribute("x1", `${cx}`);
-      stem.setAttribute("y1", `${b.y}`);
-      stem.setAttribute("x2", `${cx}`);
-      stem.setAttribute("y2", `${b.y - 2.5}`);
-      stem.setAttribute("stroke", "#b9842f");
-      stem.setAttribute("stroke-width", "0.2");
-      wrapper.appendChild(stem);
+      if (obj.type !== "icon") {
+        const cx = b.x + b.w / 2;
+        const stem = svgEl("line");
+        stem.setAttribute("x1", `${cx}`);
+        stem.setAttribute("y1", `${b.y}`);
+        stem.setAttribute("x2", `${cx}`);
+        stem.setAttribute("y2", `${b.y - 2.5}`);
+        stem.setAttribute("stroke", "#b9842f");
+        stem.setAttribute("stroke-width", "0.2");
+        wrapper.appendChild(stem);
 
-      const rotHandle = svgEl("circle") as SVGCircleElement;
-      rotHandle.setAttribute("cx", `${cx}`);
-      rotHandle.setAttribute("cy", `${b.y - 2.5}`);
-      rotHandle.setAttribute("r", "1");
-      rotHandle.setAttribute("fill", "#b9842f");
-      rotHandle.style.pointerEvents = "all";
-      rotHandle.style.cursor = "grab";
-      rotHandle.dataset.type = "rotate";
-      rotHandle.dataset.objectId = obj.id;
-      wrapper.appendChild(rotHandle);
+        const rotHandle = svgEl("circle") as SVGCircleElement;
+        rotHandle.setAttribute("cx", `${cx}`);
+        rotHandle.setAttribute("cy", `${b.y - 2.5}`);
+        rotHandle.setAttribute("r", "1");
+        rotHandle.setAttribute("fill", "#b9842f");
+        rotHandle.style.pointerEvents = "all";
+        rotHandle.style.cursor = "grab";
+        rotHandle.dataset.type = "rotate";
+        rotHandle.dataset.objectId = obj.id;
+        wrapper.appendChild(rotHandle);
+      }
     }
   }
 }

--- a/src/editor/palette.ts
+++ b/src/editor/palette.ts
@@ -7,12 +7,15 @@ export type PaletteItem =
   | { category: "area-terrain"; shape: "circle" | "polygon"; label: string }
   | { category: "objective" }
   | { category: "deployment-zone"; player: "attacker" | "defender" }
-  | { category: "annotation"; kind: "text" | "arrow" };
+  | { category: "annotation"; kind: "text" | "arrow" }
+  | { category: "icon"; iconType: "skull" | "fortress"; label: string };
 
 const FIXED_ITEMS: PaletteItem[] = [
   { category: "area-terrain", shape: "circle", label: "Forest" },
   { category: "area-terrain", shape: "circle", label: "Crater" },
   { category: "area-terrain", shape: "circle", label: "Rubble" },
+  { category: "icon", iconType: "skull", label: "Skull" },
+  { category: "icon", iconType: "fortress", label: "Fortress" },
   { category: "objective" },
   { category: "deployment-zone", player: "attacker" },
   { category: "deployment-zone", player: "defender" },
@@ -26,6 +29,7 @@ const SECTION_LABELS: Record<string, string> = {
   objective: "Objectives",
   "deployment-zone": "Deployment",
   annotation: "Annotations",
+  icon: "Icons",
 };
 
 function itemIcon(item: PaletteItem): string {
@@ -37,6 +41,7 @@ function itemIcon(item: PaletteItem): string {
   }
   if (item.category === "objective") return "①";
   if (item.category === "deployment-zone") return item.player === "attacker" ? "🔴" : "🔵";
+  if (item.category === "icon") return item.iconType === "skull" ? "💀" : "🏰";
   return item.kind === "text" ? "T" : "→";
 }
 
@@ -45,6 +50,7 @@ function itemLabel(item: PaletteItem): string {
   if (item.category === "area-terrain") return item.label;
   if (item.category === "objective") return "Objective";
   if (item.category === "deployment-zone") return item.player === "attacker" ? "Attacker Zone" : "Defender Zone";
+  if (item.category === "icon") return item.label;
   return item.kind === "text" ? "Text Label" : "Arrow";
 }
 
@@ -130,6 +136,9 @@ export function createObjectFromPalette(
       endX: item.kind === "arrow" ? x + 5 : undefined,
       endY: item.kind === "arrow" ? y + 5 : undefined,
     };
+  }
+  if (item.category === "icon") {
+    return { id, type: "icon", iconType: item.iconType, x, y, rotation: 0 };
   }
   const _exhaustive: never = item;
   throw new Error(`Unhandled PaletteItem category: ${(_exhaustive as { category: string }).category}`);

--- a/src/editor/scene.test.ts
+++ b/src/editor/scene.test.ts
@@ -146,6 +146,34 @@ describe("sceneToConfig with icons", () => {
     const config = sceneToConfig(emptyScene(), RECT_TEMPLATES);
     expect(config.terrain.layout["editor"].icons).toBeUndefined();
   });
+
+  it("includes the player tag when set", () => {
+    const scene: Scene = {
+      ...emptyScene(),
+      objects: [{
+        id: "ic1", type: "icon", iconType: "fortress",
+        x: 8, y: 10, rotation: 0, player: "attacker",
+      }],
+    };
+    const config = sceneToConfig(scene, RECT_TEMPLATES);
+    expect(config.terrain.layout["editor"].icons).toEqual([
+      { type: "fortress", pos: [10, 12], player: "attacker" },
+    ]);
+  });
+
+  it("omits player when the icon has none", () => {
+    const scene: Scene = {
+      ...emptyScene(),
+      objects: [{
+        id: "ic2", type: "icon", iconType: "skull",
+        x: 8, y: 10, rotation: 0,
+      }],
+    };
+    const config = sceneToConfig(scene, RECT_TEMPLATES);
+    expect(config.terrain.layout["editor"].icons).toEqual([
+      { type: "skull", pos: [10, 12] },
+    ]);
+  });
 });
 
 describe("sceneToConfig with centerHoleRadius", () => {

--- a/src/editor/scene.test.ts
+++ b/src/editor/scene.test.ts
@@ -127,6 +127,27 @@ describe("sceneToConfig", () => {
   });
 });
 
+describe("sceneToConfig with icons", () => {
+  it("emits layout.editor.icons with pos at the object center", () => {
+    const scene: Scene = {
+      ...emptyScene(),
+      objects: [{
+        id: "ic1", type: "icon", iconType: "skull",
+        x: 8, y: 10, rotation: 0,
+      }],
+    };
+    const config = sceneToConfig(scene, RECT_TEMPLATES);
+    expect(config.terrain.layout["editor"].icons).toEqual([
+      { type: "skull", pos: [10, 12] },
+    ]);
+  });
+
+  it("omits the icons key when there are no icon objects", () => {
+    const config = sceneToConfig(emptyScene(), RECT_TEMPLATES);
+    expect(config.terrain.layout["editor"].icons).toBeUndefined();
+  });
+});
+
 describe("sceneToConfig with centerHoleRadius", () => {
   it("emits mask_center on both players when centerHoleRadius is set", () => {
     const scene: Scene = { ...emptyScene(), centerHoleRadius: 9 };

--- a/src/editor/scene.ts
+++ b/src/editor/scene.ts
@@ -1,5 +1,6 @@
 import { templateBounds, type BuildingPlacement } from "../building-coordinates.js";
-import type { AreaTerrain } from "../terrain-config.js";
+import type { AreaTerrain, IconPlacement } from "../terrain-config.js";
+import { ICON_SIZE } from "../icons.js";
 import type {
   Annotation,
   DeploymentConfig,
@@ -49,12 +50,18 @@ export type AnnotationObject = SceneObjectBase & {
   endY?: number;
 };
 
+export type IconObject = SceneObjectBase & {
+  type: "icon";
+  iconType: "skull" | "fortress";
+};
+
 export type SceneObject =
   | BuildingObject
   | AreaTerrainObject
   | ObjectiveObject
   | DeploymentZoneObject
-  | AnnotationObject;
+  | AnnotationObject
+  | IconObject;
 
 export type Scene = {
   boardWidth: number;
@@ -145,6 +152,13 @@ export function sceneToConfig(
     .filter((o): o is ObjectiveObject => o.type === "objective")
     .map((o) => ({ x: o.x, y: o.y, number: o.number }));
 
+  const iconItems: IconPlacement[] = scene.objects
+    .filter((o): o is IconObject => o.type === "icon")
+    .map((o) => ({
+      type: o.iconType,
+      pos: [o.x + ICON_SIZE / 2, o.y + ICON_SIZE / 2],
+    }));
+
   const deployment: DeploymentConfig = {
     name: scene.missionName,
     home_edge: scene.homeEdge,
@@ -168,7 +182,12 @@ export function sceneToConfig(
     deployment,
     terrain: {
       templates,
-      layout: { editor: { buildings } },
+      layout: {
+        editor: {
+          buildings,
+          ...(iconItems.length > 0 && { icons: iconItems }),
+        },
+      },
       layout_name: "editor",
       ...(areaTerrainItems.length > 0 && { area_terrain: areaTerrainItems }),
     },

--- a/src/editor/scene.ts
+++ b/src/editor/scene.ts
@@ -53,6 +53,7 @@ export type AnnotationObject = SceneObjectBase & {
 export type IconObject = SceneObjectBase & {
   type: "icon";
   iconType: "skull" | "fortress";
+  player?: "attacker" | "defender";
 };
 
 export type SceneObject =
@@ -157,6 +158,7 @@ export function sceneToConfig(
     .map((o) => ({
       type: o.iconType,
       pos: [o.x + ICON_SIZE / 2, o.y + ICON_SIZE / 2],
+      ...(o.player && { player: o.player }),
     }));
 
   const deployment: DeploymentConfig = {

--- a/src/icons.test.ts
+++ b/src/icons.test.ts
@@ -10,7 +10,7 @@ const defsEl = (): SVGElement =>
 describe("injectIconDefs", () => {
   it("builds a themed <g id='icon-skull'> with a circle and a glyph path", () => {
     const defs = defsEl();
-    injectIconDefs(["skull"], defs, baseTheme);
+    injectIconDefs([{ type: "skull", pos: [0, 0] }], defs, baseTheme);
     const group = defs.querySelector("#icon-skull");
     expect(group).not.toBeNull();
     const circle = group!.querySelector("circle");
@@ -22,24 +22,61 @@ describe("injectIconDefs", () => {
     expect(group!.querySelector("path")).not.toBeNull();
   });
 
-  it("dedupes repeated types", () => {
+  it("dedupes repeated (type, player) combos", () => {
     const defs = defsEl();
-    injectIconDefs(["skull", "skull"], defs, baseTheme);
+    injectIconDefs(
+      [{ type: "skull", pos: [0, 0] }, { type: "skull", pos: [1, 1] }],
+      defs,
+      baseTheme,
+    );
     expect(defs.querySelectorAll("#icon-skull")).toHaveLength(1);
   });
 
-  it("fills fortress cutouts with the circle fill, body with the glyph fill", () => {
+  it("fills fortress cutouts with the disk fill, body with the glyph fill", () => {
     const defs = defsEl();
-    injectIconDefs(["fortress"], defs, baseTheme);
+    injectIconDefs([{ type: "fortress", pos: [0, 0] }], defs, baseTheme);
     const rects = [...defs.querySelectorAll("#icon-fortress rect")];
     expect(rects.some((r) => r.getAttribute("fill") === baseTheme.icon.glyph.fill)).toBe(true);
     expect(rects.some((r) => r.getAttribute("fill") === baseTheme.icon.circle.fill)).toBe(true);
   });
 
-  it("throws on an unknown icon type", () => {
-    expect(() => injectIconDefs(["dragon"], defsEl(), baseTheme)).toThrow(
-      /unknown icon type: dragon/,
+  it("tints a player-tagged disk and its cutouts with the deployment fill", () => {
+    const defs = defsEl();
+    injectIconDefs(
+      [{ type: "fortress", pos: [0, 0], player: "attacker" }],
+      defs,
+      baseTheme,
     );
+    const group = defs.querySelector("#icon-fortress-attacker");
+    expect(group).not.toBeNull();
+    const circle = group!.querySelector("circle")!;
+    expect(circle.getAttribute("fill")).toBe(baseTheme.deployment.attacker.fill);
+    // only the fill is tinted; the border stroke stays neutral
+    expect(circle.getAttribute("stroke")).toBe(baseTheme.icon.circle.stroke);
+    const rects = [...group!.querySelectorAll("rect")];
+    // cutouts take the disk (deployment) fill; body keeps the glyph fill
+    expect(rects.some((r) => r.getAttribute("fill") === baseTheme.deployment.attacker.fill)).toBe(true);
+    expect(rects.some((r) => r.getAttribute("fill") === baseTheme.icon.glyph.fill)).toBe(true);
+  });
+
+  it("emits distinct defs for the same type with different players", () => {
+    const defs = defsEl();
+    injectIconDefs(
+      [
+        { type: "fortress", pos: [0, 0], player: "attacker" },
+        { type: "fortress", pos: [1, 1], player: "defender" },
+      ],
+      defs,
+      baseTheme,
+    );
+    expect(defs.querySelector("#icon-fortress-attacker")).not.toBeNull();
+    expect(defs.querySelector("#icon-fortress-defender")).not.toBeNull();
+  });
+
+  it("throws on an unknown icon type", () => {
+    expect(() =>
+      injectIconDefs([{ type: "dragon", pos: [0, 0] }], defsEl(), baseTheme),
+    ).toThrow(/unknown icon type: dragon/);
   });
 });
 
@@ -50,6 +87,13 @@ describe("makeIcons", () => {
     expect(use.getAttribute("href")).toBe("#icon-skull");
     expect(use.getAttribute("transform")).toBe(
       `translate(${10 - ICON_SIZE / 2} ${20 - ICON_SIZE / 2})`,
+    );
+  });
+
+  it("references the tinted def id for a player-tagged placement", () => {
+    const g = makeIcons([{ type: "fortress", pos: [0, 0], player: "defender" }]);
+    expect(g.querySelector("use")!.getAttribute("href")).toBe(
+      "#icon-fortress-defender",
     );
   });
 

--- a/src/icons.test.ts
+++ b/src/icons.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from "vitest";
+import { injectIconDefs, makeIcons, ICON_SIZE } from "./icons.js";
+import { baseTheme } from "./presets/theme.js";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const defsEl = (): SVGElement =>
+  document.createElementNS(SVG_NS, "defs") as SVGElement;
+
+describe("injectIconDefs", () => {
+  it("builds a themed <g id='icon-skull'> with a circle and a glyph path", () => {
+    const defs = defsEl();
+    injectIconDefs(["skull"], defs, baseTheme);
+    const group = defs.querySelector("#icon-skull");
+    expect(group).not.toBeNull();
+    const circle = group!.querySelector("circle");
+    expect(circle).not.toBeNull();
+    expect(circle!.getAttribute("fill")).toBe(baseTheme.icon.circle.fill);
+    expect(circle!.getAttribute("stroke-width")).toBe(
+      `${baseTheme.icon.circle.stroke_width}`,
+    );
+    expect(group!.querySelector("path")).not.toBeNull();
+  });
+
+  it("dedupes repeated types", () => {
+    const defs = defsEl();
+    injectIconDefs(["skull", "skull"], defs, baseTheme);
+    expect(defs.querySelectorAll("#icon-skull")).toHaveLength(1);
+  });
+
+  it("fills fortress cutouts with the circle fill, body with the glyph fill", () => {
+    const defs = defsEl();
+    injectIconDefs(["fortress"], defs, baseTheme);
+    const rects = [...defs.querySelectorAll("#icon-fortress rect")];
+    expect(rects.some((r) => r.getAttribute("fill") === baseTheme.icon.glyph.fill)).toBe(true);
+    expect(rects.some((r) => r.getAttribute("fill") === baseTheme.icon.circle.fill)).toBe(true);
+  });
+
+  it("throws on an unknown icon type", () => {
+    expect(() => injectIconDefs(["dragon"], defsEl(), baseTheme)).toThrow(
+      /unknown icon type: dragon/,
+    );
+  });
+});
+
+describe("makeIcons", () => {
+  it("emits a <use> recentered on pos", () => {
+    const g = makeIcons([{ type: "skull", pos: [10, 20] }]);
+    const use = g.querySelector("use")!;
+    expect(use.getAttribute("href")).toBe("#icon-skull");
+    expect(use.getAttribute("transform")).toBe(
+      `translate(${10 - ICON_SIZE / 2} ${20 - ICON_SIZE / 2})`,
+    );
+  });
+
+  it("throws on an unknown icon type", () => {
+    expect(() => makeIcons([{ type: "dragon", pos: [0, 0] }])).toThrow(
+      /unknown icon type: dragon/,
+    );
+  });
+});

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,0 +1,168 @@
+import { applyAttributes, makeElement } from "./dom-helpers.js";
+import type { IconPlacement } from "./terrain-config.js";
+import type { Theme } from "./theme.js";
+
+/** Bounding-box edge of an icon, in inches. */
+export const ICON_SIZE = 4;
+
+export type IconShape =
+  | { tag: "circle"; cx: number; cy: number; r: number }
+  | { tag: "ellipse"; cx: number; cy: number; rx: number; ry: number }
+  | { tag: "rect"; x: number; y: number; width: number; height: number }
+  | { tag: "path"; d: string };
+
+/**
+ * A predefined icon, authored in a 4×4" box with the circle centered at (2,2).
+ * `glyph.body` is glyph-colored; `glyph.cutouts` are painted with the circle
+ * fill so they read as the disk background; `glyph.transform` scales imported
+ * art into the box (the circle is never transformed, so its border stays in
+ * inches).
+ */
+export type IconDef = {
+  circle: { cx: number; cy: number; r: number };
+  glyph: { transform?: string; body: IconShape[]; cutouts?: IconShape[] };
+};
+
+// Classic round skull (domed cranium, two round eye-socket holes, four teeth,
+// no nose), adapted from a 32×32 source path; eye holes let the disk show
+// through. Scaled to ~2.8" and centered: translate(0.6) + scale(0.0875).
+const SKULL_PATH =
+  "M16 0C7.164 0 0 6.27 0 14c0 4.383 2.305 8.29 5.906 10.855.602.434.95 1.133" +
+  ".844 1.872l-.586 4.136A.991.991 0 0 0 7.144 32H12v-3.5c0-.273.227-.5.5-.5h1" +
+  "c.273 0 .5.227.5.5V32h4v-3.5c0-.273.227-.5.5-.5h1c.273 0 .5.227.5.5V32h4.855" +
+  "c.606 0 1.07-.54.98-1.137l-.585-4.136c-.105-.735.238-1.438.844-1.872C29.695 " +
+  "22.29 32 18.383 32 14c0-7.73-7.164-14-16-14Zm-6 20c-2.207 0-4-1.793-4-4s1.793" +
+  "-4 4-4 4 1.793 4 4-1.793 4-4 4Zm12 0c-2.207 0-4-1.793-4-4s1.793-4 4-4 4 1.793 " +
+  "4 4-1.793 4-4 4Zm0 0";
+
+const skull: IconDef = {
+  circle: { cx: 2, cy: 2, r: 1.875 },
+  glyph: {
+    transform: "translate(0.6 0.6) scale(0.0875)",
+    body: [{ tag: "path", d: SKULL_PATH }],
+  },
+};
+
+// Single keep: one battlemented tower with crenellation notches, two arrow
+// slits, and an arched gate (cutouts). Authored directly in inch coordinates.
+const fortress: IconDef = {
+  circle: { cx: 2, cy: 2, r: 1.875 },
+  glyph: {
+    body: [{ tag: "rect", x: 1.1, y: 0.85, width: 1.8, height: 2.3 }],
+    cutouts: [
+      { tag: "rect", x: 1.325, y: 0.85, width: 0.3, height: 0.32 },
+      { tag: "rect", x: 1.85, y: 0.85, width: 0.3, height: 0.32 },
+      { tag: "rect", x: 2.375, y: 0.85, width: 0.3, height: 0.32 },
+      { tag: "rect", x: 1.42, y: 1.5, width: 0.16, height: 0.5 },
+      { tag: "rect", x: 2.42, y: 1.5, width: 0.16, height: 0.5 },
+      { tag: "path", d: "M1.68 3.15 L1.68 2.55 Q2 2.25 2.32 2.55 L2.32 3.15 Z" },
+    ],
+  },
+};
+
+export const icons: Record<string, IconDef> = { skull, fortress };
+
+function makeShape(shape: IconShape): SVGElement {
+  switch (shape.tag) {
+    case "circle": {
+      const el = makeElement("circle");
+      el.setAttribute("cx", `${shape.cx}`);
+      el.setAttribute("cy", `${shape.cy}`);
+      el.setAttribute("r", `${shape.r}`);
+      return el;
+    }
+    case "ellipse": {
+      const el = makeElement("ellipse");
+      el.setAttribute("cx", `${shape.cx}`);
+      el.setAttribute("cy", `${shape.cy}`);
+      el.setAttribute("rx", `${shape.rx}`);
+      el.setAttribute("ry", `${shape.ry}`);
+      return el;
+    }
+    case "rect": {
+      const el = makeElement("rect");
+      el.setAttribute("x", `${shape.x}`);
+      el.setAttribute("y", `${shape.y}`);
+      el.setAttribute("width", `${shape.width}`);
+      el.setAttribute("height", `${shape.height}`);
+      return el;
+    }
+    case "path": {
+      const el = makeElement("path");
+      el.setAttribute("d", shape.d);
+      return el;
+    }
+  }
+}
+
+/**
+ * Appends one `<g id="icon-<type>">` per distinct used type into `defs`: a
+ * background circle styled by `theme.icon.circle`, then a glyph group whose
+ * body shapes take `theme.icon.glyph` and whose cutouts take the circle fill.
+ * Throws on an unknown type.
+ */
+export function injectIconDefs(
+  types: string[],
+  defs: SVGElement,
+  theme: Theme,
+): void {
+  const seen = new Set<string>();
+  for (const type of types) {
+    if (seen.has(type)) continue;
+    seen.add(type);
+    const def = icons[type];
+    if (!def) throw new Error(`unknown icon type: ${type}`);
+
+    const group = makeElement("g");
+    group.setAttribute("id", `icon-${type}`);
+
+    const circle = makeElement("circle");
+    circle.setAttribute("cx", `${def.circle.cx}`);
+    circle.setAttribute("cy", `${def.circle.cy}`);
+    circle.setAttribute("r", `${def.circle.r}`);
+    applyAttributes(circle, theme.icon.circle);
+    group.appendChild(circle);
+
+    const glyph = makeElement("g");
+    if (def.glyph.transform) glyph.setAttribute("transform", def.glyph.transform);
+    for (const shape of def.glyph.body) {
+      const el = makeShape(shape);
+      applyAttributes(el, theme.icon.glyph);
+      glyph.appendChild(el);
+    }
+    for (const shape of def.glyph.cutouts ?? []) {
+      const el = makeShape(shape);
+      el.setAttribute("fill", `${theme.icon.circle.fill}`);
+      glyph.appendChild(el);
+    }
+    group.appendChild(glyph);
+    defs.appendChild(group);
+  }
+}
+
+/**
+ * Builds a `<g id="icons">` of `<use>` elements, one per placement, each
+ * referencing its `#icon-<type>` def and translated so the 4×4" design box is
+ * recentered on `pos`. Throws on an unknown type.
+ */
+export function makeIcons(placements: IconPlacement[]): SVGElement {
+  const group = makeElement("g");
+  group.setAttribute("id", "icons");
+  let counter = 0;
+  for (const placement of placements) {
+    if (!icons[placement.type]) {
+      throw new Error(`unknown icon type: ${placement.type}`);
+    }
+    const use = makeElement("use");
+    use.setAttribute("href", `#icon-${placement.type}`);
+    const [x, y] = placement.pos;
+    use.setAttribute(
+      "transform",
+      `translate(${x - ICON_SIZE / 2} ${y - ICON_SIZE / 2})`,
+    );
+    use.setAttribute("id", `icon-${counter}`);
+    group.appendChild(use);
+    counter++;
+  }
+  return group;
+}

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -95,32 +95,44 @@ function makeShape(shape: IconShape): SVGElement {
   }
 }
 
+/** Def element id for an icon, suffixed by player when the disk is tinted. */
+function iconDefId(type: string, player?: "attacker" | "defender"): string {
+  return player ? `icon-${type}-${player}` : `icon-${type}`;
+}
+
 /**
- * Appends one `<g id="icon-<type>">` per distinct used type into `defs`: a
- * background circle styled by `theme.icon.circle`, then a glyph group whose
- * body shapes take `theme.icon.glyph` and whose cutouts take the circle fill.
- * Throws on an unknown type.
+ * Appends one `<g id="icon-<type>[-<player>]">` per distinct (type, player) pair
+ * used in `placements`. The disk fill resolves from `theme.deployment[player]`
+ * when tagged, else `theme.icon.circle`; the glyph body takes `theme.icon.glyph`
+ * and the cutouts take the resolved disk fill so they read as the disk showing
+ * through. Throws on an unknown type.
  */
 export function injectIconDefs(
-  types: string[],
+  placements: IconPlacement[],
   defs: SVGElement,
   theme: Theme,
 ): void {
   const seen = new Set<string>();
-  for (const type of types) {
-    if (seen.has(type)) continue;
-    seen.add(type);
+  for (const { type, player } of placements) {
+    const id = iconDefId(type, player);
+    if (seen.has(id)) continue;
+    seen.add(id);
     const def = icons[type];
     if (!def) throw new Error(`unknown icon type: ${type}`);
 
+    const diskFill = player
+      ? `${theme.deployment[player].fill}`
+      : `${theme.icon.circle.fill}`;
+
     const group = makeElement("g");
-    group.setAttribute("id", `icon-${type}`);
+    group.setAttribute("id", id);
 
     const circle = makeElement("circle");
     circle.setAttribute("cx", `${def.circle.cx}`);
     circle.setAttribute("cy", `${def.circle.cy}`);
     circle.setAttribute("r", `${def.circle.r}`);
     applyAttributes(circle, theme.icon.circle);
+    circle.setAttribute("fill", diskFill);
     group.appendChild(circle);
 
     const glyph = makeElement("g");
@@ -132,7 +144,7 @@ export function injectIconDefs(
     }
     for (const shape of def.glyph.cutouts ?? []) {
       const el = makeShape(shape);
-      el.setAttribute("fill", `${theme.icon.circle.fill}`);
+      el.setAttribute("fill", diskFill);
       glyph.appendChild(el);
     }
     group.appendChild(glyph);
@@ -154,7 +166,7 @@ export function makeIcons(placements: IconPlacement[]): SVGElement {
       throw new Error(`unknown icon type: ${placement.type}`);
     }
     const use = makeElement("use");
-    use.setAttribute("href", `#icon-${placement.type}`);
+    use.setAttribute("href", `#${iconDefId(placement.type, placement.player)}`);
     const [x, y] = placement.pos;
     use.setAttribute(
       "transform",

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,11 +28,11 @@ function injectDefs(svg: SVGElement, config: FullConfig, theme: Theme) {
   injectTemplateDefs(config.terrain.templates, defs, templateProps);
 
   if (hasSelectedLayout(config)) {
-    const iconTypes = getLayoutIcons(
+    const iconPlacements = getLayoutIcons(
       config.terrain,
       config.terrain.layout_name,
-    ).map((i) => i.type);
-    if (iconTypes.length > 0) injectIconDefs(iconTypes, defs, theme);
+    );
+    if (iconPlacements.length > 0) injectIconDefs(iconPlacements, defs, theme);
   }
 
   const hasArrow = config.annotations?.some((a) => a.kind === "arrow");

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,12 @@
 import { injectTemplateDefs, makeBuildings } from "./buildings.js";
+import { injectIconDefs, makeIcons } from "./icons.js";
 import { applyAttributes, makeElement } from "./dom-helpers.js";
 import { baseTheme } from "./presets/theme.js";
-import { DEFAULT_AREA_TERRAIN_SIZE, getLayoutBuildings } from "./terrain-config.js";
+import {
+  DEFAULT_AREA_TERRAIN_SIZE,
+  getLayoutBuildings,
+  getLayoutIcons,
+} from "./terrain-config.js";
 import type { Theme } from "./theme.js";
 import type { FullConfig } from "./types.js";
 
@@ -21,6 +26,14 @@ function injectDefs(svg: SVGElement, config: FullConfig, theme: Theme) {
     ...theme.building.template,
   };
   injectTemplateDefs(config.terrain.templates, defs, templateProps);
+
+  if (hasSelectedLayout(config)) {
+    const iconTypes = getLayoutIcons(
+      config.terrain,
+      config.terrain.layout_name,
+    ).map((i) => i.type);
+    if (iconTypes.length > 0) injectIconDefs(iconTypes, defs, theme);
+  }
 
   const hasArrow = config.annotations?.some((a) => a.kind === "arrow");
   if (hasArrow) {
@@ -300,6 +313,14 @@ export function makeMissionCard(
   const annotations = makeAnnotations(config, theme);
   if (annotations) {
     svg.appendChild(annotations);
+  }
+
+  if (hasSelectedLayout(config)) {
+    const iconPlacements = getLayoutIcons(
+      config.terrain,
+      config.terrain.layout_name,
+    );
+    if (iconPlacements.length > 0) svg.appendChild(makeIcons(iconPlacements));
   }
 
   return svg;

--- a/src/presets/terrain.ts
+++ b/src/presets/terrain.ts
@@ -6,11 +6,11 @@ import type { TerrainConfig } from "../terrain-config.js";
 /** Built-in building templates and numbered layouts. */
 export const gwTerrain: TerrainConfig = {
   templates: {
-    "large-area": { width: 7, height: 11 },
+    "large-area": { width: 7, height: 11.5 },
     "small-area": { width: 4, height: 6 },
-    pipes: { width: 6, height: 2 },
+    "small-pipes": { width: 6, height: 2 },
     "large-pipes": { width: 10, height: 2.5 },
-    shoe: { points: [[0, 0], [8, 0], [2, 11.5], [0, 11.5]] },
+    shoe: { points: [[0, 0], [2, 0], [8, 11.5], [0, 11.5]] },
   },
   layout: {
     "1": {
@@ -18,6 +18,15 @@ export const gwTerrain: TerrainConfig = {
         { type: "large-pipes", corners: { BL: [12, 6], TL: [14.5, 6] } },
         { type: "large-area", corners: { TL: [18.5, 0], TR: [25.5, 0] } },
         { type: "large-area", corners: { TR: [17, 19.5] } },
+        { type: "small-pipes", corners: { BL: [17, 31], TL: [19, 31] } },
+        { type: "small-pipes", corners: { BL: [11, 39] } },
+        { type: "shoe", corners: { TL: [25, 16.25] } },
+        { type: "small-area", corners: { BL: [19.5, 44] } },
+        { type: "small-area", corners: { BR: [23.5, 38], TR: [29.5, 38] } },
+      ],
+      icons: [
+        { type: "skull", pos: [15, 22] },
+        { type: "fortress", pos: [45, 22] },
       ],
     },
   },

--- a/src/presets/terrain.ts
+++ b/src/presets/terrain.ts
@@ -26,8 +26,8 @@ export const gwTerrain: TerrainConfig = {
       ],
       icons: [
         { type: "skull", pos: [30, 22] },
-        { type: "fortress", pos: [46.5, 19] },
-        { type: "fortress", pos: [13.5, 25] },
+        { type: "fortress", pos: [46.5, 19], player: "defender" },
+        { type: "fortress", pos: [13.5, 25], player: "attacker" },
         { type: "skull", pos: [22, 5] },
         { type: "skull", pos: [38, 39] },
       ],

--- a/src/presets/terrain.ts
+++ b/src/presets/terrain.ts
@@ -25,8 +25,11 @@ export const gwTerrain: TerrainConfig = {
         { type: "small-area", corners: { BR: [23.5, 38], TR: [29.5, 38] } },
       ],
       icons: [
-        { type: "skull", pos: [15, 22] },
-        { type: "fortress", pos: [45, 22] },
+        { type: "skull", pos: [30, 22] },
+        { type: "fortress", pos: [46.5, 19] },
+        { type: "fortress", pos: [13.5, 25] },
+        { type: "skull", pos: [22, 5] },
+        { type: "skull", pos: [38, 39] },
       ],
     },
   },

--- a/src/presets/terrain.ts
+++ b/src/presets/terrain.ts
@@ -6,50 +6,18 @@ import type { TerrainConfig } from "../terrain-config.js";
 /** Built-in building templates and numbered layouts. */
 export const gwTerrain: TerrainConfig = {
   templates: {
-    "4x6": { width: 4, height: 6 },
-    "6x12": { width: 6, height: 12 },
-    "5x10": { width: 5, height: 10 },
-    "ruins-a": {
-      points: [
-        [1.5, 0],
-        [4.5, 0.6],
-        [5.5, 2.2],
-        [7, 4.5],
-        [5.8, 6.5],
-        [6, 8.5],
-        [4, 11],
-        [2.5, 9.5],
-        [2, 6.5],
-        [0, 4],
-        [1, 1.8],
-      ],
-    },
-    "curved-bastion": {
-      width: 8,
-      height: 8,
-      start: [4, 0],
-      segments: [
-        { cubic: [8, 4], controls: [[6.21, 0], [8, 1.79]] },
-        { cubic: [4, 8], controls: [[8, 6.21], [6.21, 8]] },
-        { cubic: [0, 4], controls: [[1.79, 8], [0, 6.21]] },
-        { cubic: [4, 0], controls: [[0, 1.79], [1.79, 0]] },
-      ],
-    },
+    "large-area": { width: 7, height: 11 },
+    "small-area": { width: 4, height: 6 },
+    pipes: { width: 6, height: 2 },
+    "large-pipes": { width: 10, height: 2.5 },
+    shoe: { points: [[0, 0], [8, 0], [2, 11.5], [0, 11.5]] },
   },
   layout: {
     "1": {
       buildings: [
-        { type: "6x12", corners: { TL: [8, 6], TR: [14, 6] } },
-        { type: "4x6", corners: { TL: [24, 4], TR: [28, 4] } },
-        { type: "5x10", corners: { TL: [40, 8], TR: [45, 8] } },
-        { type: "ruins-a", corners: { TL: [22, 14], TR: [29, 14] } },
-      ],
-    },
-    "2": {
-      buildings: [
-        { type: "6x12", corners: { TL: [6, 10], TR: [12, 10] } },
-        { type: "4x6", corners: { TL: [30, 8], TR: [34, 8] } },
-        { type: "curved-bastion", corners: { TL: [20, 24], TR: [28, 24] } },
+        { type: "large-pipes", corners: { BL: [12, 6], TL: [14.5, 6] } },
+        { type: "large-area", corners: { TL: [18.5, 0], TR: [25.5, 0] } },
+        { type: "large-area", corners: { TR: [17, 19.5] } },
       ],
     },
   },

--- a/src/presets/theme.ts
+++ b/src/presets/theme.ts
@@ -63,4 +63,8 @@ export const baseTheme: Theme = {
       stroke_width: 0.3,
     },
   },
+  icon: {
+    circle: { fill: "#e8dcc0", stroke: "#33312c", stroke_width: 0.25 },
+    glyph: { fill: "#33312c" },
+  },
 };

--- a/src/terrain-config.test.ts
+++ b/src/terrain-config.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import yaml from "js-yaml";
-import { getLayoutBuildings, type TerrainConfig } from "./terrain-config";
+import {
+  getLayoutBuildings,
+  getLayoutIcons,
+  type TerrainConfig,
+} from "./terrain-config";
 import { resolveBuilding } from "./building-coordinates";
 
 const terrain: TerrainConfig = {
@@ -50,5 +54,27 @@ describe("placeholder gw.yml", () => {
         ).not.toThrow();
       }
     }
+  });
+});
+
+describe("getLayoutIcons", () => {
+  const t: TerrainConfig = {
+    templates: {},
+    layout: {
+      "1": { buildings: [], icons: [{ type: "skull", pos: [5, 10] }] },
+      "2": { buildings: [] },
+    },
+  };
+
+  it("returns the icon placements for a layout that has them", () => {
+    expect(getLayoutIcons(t, "1")).toEqual([{ type: "skull", pos: [5, 10] }]);
+  });
+
+  it("returns [] for a layout with no icons", () => {
+    expect(getLayoutIcons(t, "2")).toEqual([]);
+  });
+
+  it("returns [] for a missing layout", () => {
+    expect(getLayoutIcons(t, "9")).toEqual([]);
   });
 });

--- a/src/terrain-config.test.ts
+++ b/src/terrain-config.test.ts
@@ -37,8 +37,8 @@ const GW_YML = fileURLToPath(
 describe("placeholder gw.yml", () => {
   const gwTerrain = yaml.load(readFileSync(GW_YML, "utf8")) as TerrainConfig;
 
-  it("defines layouts 1 and 2", () => {
-    expect(Object.keys(gwTerrain.layout).sort()).toEqual(["1", "2"]);
+  it("defines layout 1", () => {
+    expect(Object.keys(gwTerrain.layout).sort()).toEqual(["1"]);
   });
 
   it("every building in every layout resolves without throwing", () => {

--- a/src/terrain-config.test.ts
+++ b/src/terrain-config.test.ts
@@ -77,4 +77,16 @@ describe("getLayoutIcons", () => {
   it("returns [] for a missing layout", () => {
     expect(getLayoutIcons(t, "9")).toEqual([]);
   });
+
+  it("preserves a player tag on an icon placement", () => {
+    const tp: TerrainConfig = {
+      templates: {},
+      layout: {
+        "1": { buildings: [], icons: [{ type: "fortress", pos: [5, 10], player: "attacker" }] },
+      },
+    };
+    expect(getLayoutIcons(tp, "1")).toEqual([
+      { type: "fortress", pos: [5, 10], player: "attacker" },
+    ]);
+  });
 });

--- a/src/terrain-config.test.ts
+++ b/src/terrain-config.test.ts
@@ -55,6 +55,15 @@ describe("placeholder gw.yml", () => {
       }
     }
   });
+
+  it("tags the two demo fortresses with opposite players", () => {
+    const icons = gwTerrain.layout["1"].icons ?? [];
+    const players = icons
+      .filter((i) => i.type === "fortress")
+      .map((i) => i.player);
+    expect(players).toContain("attacker");
+    expect(players).toContain("defender");
+  });
 });
 
 describe("getLayoutIcons", () => {

--- a/src/terrain-config.ts
+++ b/src/terrain-config.ts
@@ -19,9 +19,13 @@ export type AreaTerrain = {
   rotation?: number;
 };
 
-/** One numbered layout: an ordered list of building placements. */
+/** A placed icon marker: `type` selects a predefined icon, `pos` is its center (inches). */
+export type IconPlacement = { type: string; pos: [number, number] };
+
+/** One numbered layout: building placements and optional icon markers. */
 export type TerrainLayout = {
   buildings: BuildingPlacement[];
+  icons?: IconPlacement[];
 };
 
 /**
@@ -50,4 +54,16 @@ export function getLayoutBuildings(
     throw new Error(`terrain has no layout named: ${layoutName}`);
   }
   return layout.buildings;
+}
+
+/**
+ * Returns the icon placements for a named layout, or `[]` when the layout is
+ * missing or has no icons. Unlike `getLayoutBuildings`, never throws — icons
+ * are optional everywhere.
+ */
+export function getLayoutIcons(
+  terrain: TerrainConfig,
+  layoutName: string,
+): IconPlacement[] {
+  return terrain.layout[layoutName]?.icons ?? [];
 }

--- a/src/terrain-config.ts
+++ b/src/terrain-config.ts
@@ -19,8 +19,16 @@ export type AreaTerrain = {
   rotation?: number;
 };
 
-/** A placed icon marker: `type` selects a predefined icon, `pos` is its center (inches). */
-export type IconPlacement = { type: string; pos: [number, number] };
+/**
+ * A placed icon marker: `type` selects a predefined icon, `pos` is its center
+ * (inches). An optional `player` tints the disk with that player's deployment
+ * colour; absent leaves the neutral theme.icon disk.
+ */
+export type IconPlacement = {
+  type: string;
+  pos: [number, number];
+  player?: "attacker" | "defender";
+};
 
 /** One numbered layout: building placements and optional icon markers. */
 export type TerrainLayout = {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -20,4 +20,6 @@ export type Theme = {
   };
   /** Keyed by area-terrain `label`; `default` is the fallback. */
   area_terrain: { default: SVGProperties } & Record<string, SVGProperties>;
+  /** Icon markers: `circle` styles the disk + border ring; `glyph` fills the art. */
+  icon: { circle: SVGProperties; glyph: SVGProperties };
 };

--- a/static/data/terrain/gw.yml
+++ b/static/data/terrain/gw.yml
@@ -58,6 +58,12 @@ layout:
         corners: { BR: [23.5, 38], TR: [29.5, 38] }
     icons:
       - type: skull
-        pos: [15, 22]
+        pos: [30, 22]
       - type: fortress
-        pos: [45, 22]
+        pos: [46.5, 19]
+      - type: fortress
+        pos: [13.5, 25]
+      - type: skull
+        pos: [22, 5]
+      - type: skull
+        pos: [38, 39]

--- a/static/data/terrain/gw.yml
+++ b/static/data/terrain/gw.yml
@@ -18,7 +18,9 @@
 #
 # A layout may also list `icons` (sibling to `buildings`): predefined marker
 # graphics placed by their circle centre. Each is `{ type: <skull|fortress>,
-# pos: [x, y] }` in inches. Icons are styled by theme.yml and drawn on top.
+# pos: [x, y] }` in inches, with an optional `player: <attacker|defender>` that
+# tints the icon's disk with that player's deployment colour. Icons are styled
+# by theme.yml and drawn on top.
 
 templates:
   large-area: { width: 7, height: 11.5 }
@@ -61,8 +63,10 @@ layout:
         pos: [30, 22]
       - type: fortress
         pos: [46.5, 19]
+        player: defender
       - type: fortress
         pos: [13.5, 25]
+        player: attacker
       - type: skull
         pos: [22, 5]
       - type: skull

--- a/static/data/terrain/gw.yml
+++ b/static/data/terrain/gw.yml
@@ -15,6 +15,10 @@
 # (axis-aligned). A building-level `from:` or a 3rd value inside a corner
 # selects a different canvas corner. Buildings are mirrored 180 degrees
 # through the canvas centre unless `mirror: false`.
+#
+# A layout may also list `icons` (sibling to `buildings`): predefined marker
+# graphics placed by their circle centre. Each is `{ type: <skull|fortress>,
+# pos: [x, y] }` in inches. Icons are styled by theme.yml and drawn on top.
 
 templates:
   large-area: { width: 7, height: 11.5 }
@@ -52,3 +56,8 @@ layout:
 
       - type: small-area
         corners: { BR: [23.5, 38], TR: [29.5, 38] }
+    icons:
+      - type: skull
+        pos: [15, 22]
+      - type: fortress
+        pos: [45, 22]

--- a/static/data/terrain/gw.yml
+++ b/static/data/terrain/gw.yml
@@ -8,49 +8,47 @@
 # (`start` plus `segments` of line/quad/cubic Béziers, with a declared
 # `width`/`height` bounding box).
 #
-# Each building pins two of its corners (keyed by the building corner:
-# TL/TR/BL/BR — the template's bounding-box corners) to inward distances
-# from a canvas corner — by default the canvas top-left. A building-level
-# `from:` or a 3rd value inside a corner selects a different canvas
-# corner. Buildings are mirrored 180 degrees through the canvas centre
-# unless `mirror: false`.
+# Each building pins one or two of its corners (keyed by the building
+# corner: TL/TR/BL/BR — the template's bounding-box corners) to inward
+# distances from a canvas corner — by default the canvas top-left. Two
+# corners derive the rotation; a single corner implies no rotation
+# (axis-aligned). A building-level `from:` or a 3rd value inside a corner
+# selects a different canvas corner. Buildings are mirrored 180 degrees
+# through the canvas centre unless `mirror: false`.
 
 templates:
-  4x6: { width: 4, height: 6 }
-  6x12: { width: 6, height: 12 }
-  5x10: { width: 5, height: 10 }
-  ruins-a:
-    points: [[1.5, 0], [4.5, 0.6], [5.5, 2.2], [7, 4.5], [5.8, 6.5], [6, 8.5], [4, 11], [2.5, 9.5], [2, 6.5], [0, 4], [1, 1.8]]
-  curved-bastion:
-    width: 8
-    height: 8
-    start: [4, 0]
-    segments:
-      - cubic: [8, 4]
-        controls: [[6.21, 0], [8, 1.79]]
-      - cubic: [4, 8]
-        controls: [[8, 6.21], [6.21, 8]]
-      - cubic: [0, 4]
-        controls: [[1.79, 8], [0, 6.21]]
-      - cubic: [4, 0]
-        controls: [[0, 1.79], [1.79, 0]]
+  large-area: { width: 7, height: 11.5 }
+  small-area: { width: 4, height: 6 }
+
+  small-pipes: { width: 6, height: 2 }
+  large-pipes: { width: 10, height: 2.5 }
+
+  shoe:
+    points: [[0, 0], [2, 0], [8, 11.5], [0, 11.5]]
 
 layout:
   1:
     buildings:
-      - type: 6x12
-        corners: { TL: [8, 6], TR: [14, 6] }
-      - type: 4x6
-        corners: { TL: [24, 4], TR: [28, 4] }
-      - type: 5x10
-        corners: { TL: [40, 8], TR: [45, 8] }
-      - type: ruins-a
-        corners: { TL: [22, 14], TR: [29, 14] }
-  2:
-    buildings:
-      - type: 6x12
-        corners: { TL: [6, 10], TR: [12, 10] }
-      - type: 4x6
-        corners: { TL: [30, 8], TR: [34, 8] }
-      - type: curved-bastion
-        corners: { TL: [20, 24], TR: [28, 24] }
+      - type: large-pipes
+        corners: { BL: [12, 6], TL: [14.5, 6] }
+
+      - type: large-area
+        corners: { TL: [18.5, 0], TR: [25.5, 0] }
+
+      - type: large-area
+        corners: { TR: [17, 19.5] }
+
+      - type: small-pipes
+        corners: { BL: [17, 31], TL: [19, 31] }
+
+      - type: small-pipes
+        corners: { BL: [11, 39] }
+
+      - type: shoe
+        corners: { TL: [25, 16.25] }
+
+      - type: small-area
+        corners: { BL: [19.5, 44] }
+
+      - type: small-area
+        corners: { BR: [23.5, 38], TR: [29.5, 38] }

--- a/static/data/theme.yml
+++ b/static/data/theme.yml
@@ -76,3 +76,11 @@ area_terrain:
     fill: "rgba(140,130,120,0.3)"
     stroke: "#807060"
     stroke_width: 0.3
+
+icon:
+  circle:
+    fill: "#e8dcc0"
+    stroke: "#33312c"
+    stroke_width: 0.25
+  glyph:
+    fill: "#33312c"


### PR DESCRIPTION
## Summary

Adds placeable **icon markers** to the terrain layer — a skull and a single-keep fortress, each a glyph inside a bordered disk — and lets a placed icon optionally take a player's deployment colour.

- **Icon markers.** New `icons` list per layout (sibling to `buildings`) in `terrain/gw.yml`: `{ type: skull | fortress, pos: [x, y] }`, placed by circle centre (inches) and drawn on top of the card. Art is defined in code (`src/icons.ts`) and injected into `<defs>`; styling comes from a new `icon` theme category (`theme.icon.circle` / `theme.icon.glyph`), never baked into the art.
- **Player-coloured disks.** An optional `player: attacker | defender` tints only the icon's **disk fill** with that player's deployment colour (`theme.deployment[player].fill`); the glyph and border stay neutral, and untagged icons keep the parchment disk. Colour is an explicit author tag, independent of mission geometry, so terrain can overlay any mission.
- **Editor support.** Skull/fortress are draggable from the editor palette, select/move on the canvas, and a **Player colour** selector (None / Attacker / Defender) round-trips through Copy YAML.
- Also includes a preparatory **single-corner building-placement** refactor that the icon work builds on.

Icon `<defs>` are keyed by `(type, player)`, so one fortress type can render neutral, red, and green in the same card.

```yaml
layout:
  1:
    icons:
      - type: fortress
        pos: [13.5, 25]
        player: attacker   # red disk; omit for neutral
      - type: skull
        pos: [30, 22]
```

## Test Plan

- [x] `pnpm lint`, `pnpm type-check` clean
- [x] `pnpm vitest run` — 127 tests pass (icon defs/tinting/dedup, scene round-trip, gw.yml demo tags)
- [x] `pnpm gen:presets:check` — generated presets in sync with YAML
- [x] `pnpm build` — both bundles build
- [x] Visual render of GW layout 1: attacker fortress on a red disk, defender fortress on a green disk, skulls on neutral parchment, glyphs dark
- [ ] Reviewer: open `static/editor.html`, drop a fortress, set Player colour, confirm preview tints and Copy YAML emits `player`