### PR TITLE
refactor: rename layout 'buildings' key to 'templates'

### DIFF
--- a/scripts/convert-40kdc-terrain.mjs
+++ b/scripts/convert-40kdc-terrain.mjs
@@ -109,7 +109,7 @@ for (const layout of layouts) {
   if (layout.deployment_pattern_id)
     entry.deployment_pattern_id = layout.deployment_pattern_id;
   if (dispositions) entry.dispositions = dispositions;
-  entry.buildings = [...buildings, ...feat.buildings];
+  entry.templates = [...buildings, ...feat.buildings];
   if (area_terrain.length > 0) entry.area_terrain = area_terrain;
   if (features.length > 0) entry.features = features;
   if (icons.length > 0) entry.icons = icons;

--- a/src/area-terrain-layout.test.ts
+++ b/src/area-terrain-layout.test.ts
@@ -16,7 +16,7 @@ function configWithLayout(): FullConfig {
       templates: {},
       layout: {
         dc: {
-          buildings: [],
+          templates: [],
           area_terrain: [
             {
               shape: "polygon",

--- a/src/editor/presets.ts
+++ b/src/editor/presets.ts
@@ -28,7 +28,7 @@ type TemplatesYaml = {
 };
 
 type TerrainYaml = {
-  layout: Record<string, { buildings: BuildingPlacement[] }>;
+  layout: Record<string, { templates: BuildingPlacement[] }>;
 };
 
 export async function loadPreset(
@@ -62,8 +62,8 @@ export async function loadPreset(
   });
 
   const layout = terrainData.layout?.[terrainLayoutId];
-  if (layout?.buildings) {
-    for (const bld of layout.buildings) {
+  if (layout?.templates) {
+    for (const bld of layout.templates) {
       const template = templates[bld.type];
       if (!template) continue;
       const resolved = resolveBuilding({ ...bld, mirror: false }, templates, canvas);

--- a/src/editor/scene.test.ts
+++ b/src/editor/scene.test.ts
@@ -59,7 +59,7 @@ describe("sceneToConfig", () => {
     expect(config.base.size).toEqual({ width: 60, height: 44 });
     expect(config.deployment.name).toBe("Custom");
     expect(config.terrain.layout_name).toBe("editor");
-    expect(config.terrain.layout["editor"].buildings).toHaveLength(0);
+    expect(config.terrain.layout["editor"].templates).toHaveLength(0);
   });
 
   it("includes buildings from scene", () => {
@@ -71,8 +71,8 @@ describe("sceneToConfig", () => {
       }],
     };
     const config = sceneToConfig(scene, RECT_TEMPLATES);
-    expect(config.terrain.layout["editor"].buildings).toHaveLength(1);
-    expect(config.terrain.layout["editor"].buildings[0].type).toBe("4x6");
+    expect(config.terrain.layout["editor"].templates).toHaveLength(1);
+    expect(config.terrain.layout["editor"].templates[0].type).toBe("4x6");
   });
 
   it("uses attacker deployment zone vertices from scene", () => {

--- a/src/editor/scene.ts
+++ b/src/editor/scene.ts
@@ -209,7 +209,7 @@ export function sceneToConfig(
       templates,
       layout: {
         editor: {
-          buildings,
+          templates: buildings,
           ...(iconItems.length > 0 && { icons: iconItems }),
         },
       },

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -17,7 +17,7 @@ function buildMinimalConfig(): FullConfig {
       templates: { "4x6": { width: 4, height: 6 } },
       layout: {
         "1": {
-          buildings: [{ type: "4x6", corners: { TL: { x: 10, y: 0 }, TR: { x: 14, y: 0 } } }],
+          templates: [{ type: "4x6", corners: { TL: { x: 10, y: 0 }, TR: { x: 14, y: 0 } } }],
         },
       },
     },

--- a/src/presets/terrain.ts
+++ b/src/presets/terrain.ts
@@ -45,7 +45,7 @@ export const gwTerrain: TerrainConfig = {
   },
   layout: {
     "1": {
-      buildings: [
+      templates: [
         {
           type: "large-pipes",
           corners: { BL: { x: 12, y: 6 }, TL: { x: 14.5, y: 6 } },
@@ -121,7 +121,7 @@ export const gwTerrain: TerrainConfig = {
     },
     "gw-11e-crucible": {
       deployment_pattern_id: "crucible-of-battle",
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 54, y: 5 }, TR: { x: 54, y: 12 } },
@@ -470,7 +470,7 @@ export const gwTerrain: TerrainConfig = {
     },
     "gw-11e-hammer-anvil": {
       deployment_pattern_id: "hammer-and-anvil",
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 50, y: 24.5 }, TR: { x: 43, y: 24.5 } },
@@ -860,7 +860,7 @@ export const gwTerrain: TerrainConfig = {
     "take-and-hold-vs-purge-the-foe-2": {
       deployment_pattern_id: "search-and-destroy",
       dispositions: ["Take and Hold", "Purge the Foe"],
-      buildings: [
+      templates: [
         {
           type: "shoe-mirror",
           corners: { TL: { x: 35.75, y: 17 }, TR: { x: 35.75, y: 25 } },
@@ -1215,7 +1215,7 @@ export const gwTerrain: TerrainConfig = {
     "take-and-hold-mirror-1": {
       deployment_pattern_id: "tipping-point",
       dispositions: ["Take and Hold", "Take and Hold"],
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 47, y: 34 }, TR: { x: 47, y: 41 } },
@@ -1561,7 +1561,7 @@ export const gwTerrain: TerrainConfig = {
     "take-and-hold-mirror-2": {
       deployment_pattern_id: "dawn-of-war",
       dispositions: ["Take and Hold", "Take and Hold"],
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 14, y: 24.5 }, TR: { x: 7, y: 24.5 } },
@@ -1937,7 +1937,7 @@ export const gwTerrain: TerrainConfig = {
     "take-and-hold-vs-purge-the-foe-3": {
       deployment_pattern_id: "hammer-and-anvil",
       dispositions: ["Take and Hold", "Purge the Foe"],
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 53, y: 16.5 }, TR: { x: 46, y: 16.5 } },
@@ -2292,7 +2292,7 @@ export const gwTerrain: TerrainConfig = {
     "take-and-hold-mirror-3": {
       deployment_pattern_id: "search-and-destroy",
       dispositions: ["Take and Hold", "Take and Hold"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 35, y: 27.75 }, TR: { x: 27, y: 27.75 } },
@@ -2653,7 +2653,7 @@ export const gwTerrain: TerrainConfig = {
     "take-and-hold-vs-reconnaissance-3": {
       deployment_pattern_id: "search-and-destroy",
       dispositions: ["Take and Hold", "Reconnaissance"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 35.75, y: 17 }, TR: { x: 35.75, y: 25 } },
@@ -3008,7 +3008,7 @@ export const gwTerrain: TerrainConfig = {
     "take-and-hold-vs-disruption-1": {
       deployment_pattern_id: "sweeping-engagement",
       dispositions: ["Take and Hold", "Disruption"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 35.75, y: 17 }, TR: { x: 35.75, y: 25 } },
@@ -3375,7 +3375,7 @@ export const gwTerrain: TerrainConfig = {
     "take-and-hold-vs-disruption-2": {
       deployment_pattern_id: "crucible-of-battle",
       dispositions: ["Take and Hold", "Disruption"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 35.75, y: 17 }, TR: { x: 35.75, y: 25 } },
@@ -3701,7 +3701,7 @@ export const gwTerrain: TerrainConfig = {
     "take-and-hold-vs-disruption-3": {
       deployment_pattern_id: "hammer-and-anvil",
       dispositions: ["Take and Hold", "Disruption"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 35.75, y: 17 }, TR: { x: 35.75, y: 25 } },
@@ -4046,7 +4046,7 @@ export const gwTerrain: TerrainConfig = {
     },
     "sweeping-engagement-1": {
       deployment_pattern_id: "sweeping-engagement",
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 35.75, y: 17 }, TR: { x: 35.75, y: 25 } },
@@ -4381,7 +4381,7 @@ export const gwTerrain: TerrainConfig = {
     "take-and-hold-vs-priority-assets-1": {
       deployment_pattern_id: "crucible-of-battle",
       dispositions: ["Take and Hold", "Priority Assets"],
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 55, y: 16.5 }, TR: { x: 48, y: 16.5 } },
@@ -4751,7 +4751,7 @@ export const gwTerrain: TerrainConfig = {
     "take-and-hold-vs-priority-assets-2": {
       deployment_pattern_id: "hammer-and-anvil",
       dispositions: ["Take and Hold", "Priority Assets"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: {
@@ -5059,7 +5059,7 @@ export const gwTerrain: TerrainConfig = {
     "take-and-hold-vs-priority-assets-3": {
       deployment_pattern_id: "dawn-of-war",
       dispositions: ["Take and Hold", "Priority Assets"],
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 44, y: 3 }, TR: { x: 44, y: 10 } },
@@ -5441,7 +5441,7 @@ export const gwTerrain: TerrainConfig = {
     "take-and-hold-vs-reconnaissance-1": {
       deployment_pattern_id: "tipping-point",
       dispositions: ["Take and Hold", "Reconnaissance"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 35.75, y: 17 }, TR: { x: 35.75, y: 25 } },
@@ -5787,7 +5787,7 @@ export const gwTerrain: TerrainConfig = {
     "take-and-hold-vs-reconnaissance-2": {
       deployment_pattern_id: "dawn-of-war",
       dispositions: ["Take and Hold", "Reconnaissance"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 35.75, y: 17 }, TR: { x: 35.75, y: 25 } },
@@ -6172,7 +6172,7 @@ export const gwTerrain: TerrainConfig = {
     "purge-the-foe-vs-purge-the-foe-1": {
       deployment_pattern_id: "search-and-destroy",
       dispositions: ["Purge the Foe", "Purge the Foe"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: {
@@ -6539,7 +6539,7 @@ export const gwTerrain: TerrainConfig = {
     "purge-the-foe-vs-purge-the-foe-2": {
       deployment_pattern_id: "tipping-point",
       dispositions: ["Purge the Foe", "Purge the Foe"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 47.066, y: 4.894 }, TR: { x: 54.822, y: 6.854 } },
@@ -6900,7 +6900,7 @@ export const gwTerrain: TerrainConfig = {
     "purge-the-foe-vs-purge-the-foe-3": {
       deployment_pattern_id: "sweeping-engagement",
       dispositions: ["Purge the Foe", "Purge the Foe"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 7.044, y: 6.175 }, TR: { x: 11.044, y: -0.753 } },
@@ -7276,7 +7276,7 @@ export const gwTerrain: TerrainConfig = {
     "take-and-hold-vs-purge-the-foe-1": {
       deployment_pattern_id: "sweeping-engagement",
       dispositions: ["Take and Hold", "Purge the Foe"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 35.75, y: 17 }, TR: { x: 35.75, y: 25 } },
@@ -7643,7 +7643,7 @@ export const gwTerrain: TerrainConfig = {
     "disruption-vs-purge-the-foe-1": {
       deployment_pattern_id: "search-and-destroy",
       dispositions: ["Disruption", "Purge the Foe"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 35.75, y: 17 }, TR: { x: 35.75, y: 25 } },
@@ -7989,7 +7989,7 @@ export const gwTerrain: TerrainConfig = {
     "disruption-vs-purge-the-foe-2": {
       deployment_pattern_id: "tipping-point",
       dispositions: ["Disruption", "Purge the Foe"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 35, y: 27.75 }, TR: { x: 27, y: 27.75 } },
@@ -8335,7 +8335,7 @@ export const gwTerrain: TerrainConfig = {
     "disruption-vs-purge-the-foe-3": {
       deployment_pattern_id: "sweeping-engagement",
       dispositions: ["Disruption", "Purge the Foe"],
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 55, y: 5 }, TR: { x: 55, y: 12 } },
@@ -8670,7 +8670,7 @@ export const gwTerrain: TerrainConfig = {
     "purge-the-foe-vs-reconnaissance-1": {
       deployment_pattern_id: "hammer-and-anvil",
       dispositions: ["Purge the Foe", "Reconnaissance"],
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 52, y: 24.5 }, TR: { x: 45, y: 24.5 } },
@@ -9025,7 +9025,7 @@ export const gwTerrain: TerrainConfig = {
     "purge-the-foe-vs-reconnaissance-2": {
       deployment_pattern_id: "dawn-of-war",
       dispositions: ["Purge the Foe", "Reconnaissance"],
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 45, y: 3 }, TR: { x: 45, y: 10 } },
@@ -9401,7 +9401,7 @@ export const gwTerrain: TerrainConfig = {
     "purge-the-foe-vs-reconnaissance-3": {
       deployment_pattern_id: "crucible-of-battle",
       dispositions: ["Purge the Foe", "Reconnaissance"],
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 55, y: 18.5 }, TR: { x: 48, y: 18.5 } },
@@ -9771,7 +9771,7 @@ export const gwTerrain: TerrainConfig = {
     "purge-the-foe-vs-priority-assets-1": {
       deployment_pattern_id: "dawn-of-war",
       dispositions: ["Purge the Foe", "Priority Assets"],
-      buildings: [
+      templates: [
         {
           type: "large-pipes",
           corners: { TL: { x: 6, y: 6 }, TR: { x: 16, y: 6 } },
@@ -10141,7 +10141,7 @@ export const gwTerrain: TerrainConfig = {
     "purge-the-foe-vs-priority-assets-2": {
       deployment_pattern_id: "search-and-destroy",
       dispositions: ["Purge the Foe", "Priority Assets"],
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 56, y: 5 }, TR: { x: 56, y: 12 } },
@@ -10493,7 +10493,7 @@ export const gwTerrain: TerrainConfig = {
     "purge-the-foe-vs-priority-assets-3": {
       deployment_pattern_id: "hammer-and-anvil",
       dispositions: ["Purge the Foe", "Priority Assets"],
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 51, y: 29 }, TR: { x: 44, y: 29 } },
@@ -10845,7 +10845,7 @@ export const gwTerrain: TerrainConfig = {
     "disruption-vs-disruption-2": {
       deployment_pattern_id: "tipping-point",
       dispositions: ["Disruption", "Disruption"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 35, y: 27.75 }, TR: { x: 27, y: 27.75 } },
@@ -11221,7 +11221,7 @@ export const gwTerrain: TerrainConfig = {
     "disruption-vs-disruption-3": {
       deployment_pattern_id: "sweeping-engagement",
       dispositions: ["Disruption", "Disruption"],
-      buildings: [
+      templates: [
         {
           type: "small-area",
           corners: { TL: { x: 14, y: 4 }, TR: { x: 14, y: 8 } },
@@ -11597,7 +11597,7 @@ export const gwTerrain: TerrainConfig = {
     "disruption-vs-reconnaissance-3": {
       deployment_pattern_id: "search-and-destroy",
       dispositions: ["Disruption", "Reconnaissance"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 32, y: 14 }, TR: { x: 40, y: 14 } },
@@ -11952,7 +11952,7 @@ export const gwTerrain: TerrainConfig = {
     "disruption-vs-priority-assets-1": {
       deployment_pattern_id: "sweeping-engagement",
       dispositions: ["Disruption", "Priority Assets"],
-      buildings: [
+      templates: [
         {
           type: "small-area",
           corners: { TL: { x: 34, y: 25 }, TR: { x: 30, y: 25 } },
@@ -12304,7 +12304,7 @@ export const gwTerrain: TerrainConfig = {
     "disruption-vs-priority-assets-2": {
       deployment_pattern_id: "tipping-point",
       dispositions: ["Disruption", "Priority Assets"],
-      buildings: [
+      templates: [
         {
           type: "small-area",
           corners: { TL: { x: 33, y: 22 }, TR: { x: 33, y: 26 } },
@@ -12665,7 +12665,7 @@ export const gwTerrain: TerrainConfig = {
     "disruption-vs-priority-assets-3": {
       deployment_pattern_id: "search-and-destroy",
       dispositions: ["Disruption", "Priority Assets"],
-      buildings: [
+      templates: [
         {
           type: "small-area",
           corners: { TL: { x: 33, y: 18 }, TR: { x: 33, y: 22 } },
@@ -13017,7 +13017,7 @@ export const gwTerrain: TerrainConfig = {
     "reconnaissance-vs-reconnaissance-1": {
       deployment_pattern_id: "sweeping-engagement",
       dispositions: ["Reconnaissance", "Reconnaissance"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 35.75, y: 17 }, TR: { x: 35.75, y: 25 } },
@@ -13399,7 +13399,7 @@ export const gwTerrain: TerrainConfig = {
     "reconnaissance-vs-reconnaissance-3": {
       deployment_pattern_id: "tipping-point",
       dispositions: ["Reconnaissance", "Reconnaissance"],
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 55, y: 17.5 }, TR: { x: 48, y: 17.5 } },
@@ -13775,7 +13775,7 @@ export const gwTerrain: TerrainConfig = {
     "priority-assets-vs-reconnaissance-1": {
       deployment_pattern_id: "crucible-of-battle",
       dispositions: ["Priority Assets", "Reconnaissance"],
-      buildings: [
+      templates: [
         {
           type: "shoe",
           corners: { TL: { x: 35.75, y: 17 }, TR: { x: 35.75, y: 25 } },
@@ -14130,7 +14130,7 @@ export const gwTerrain: TerrainConfig = {
     "priority-assets-vs-reconnaissance-2": {
       deployment_pattern_id: "tipping-point",
       dispositions: ["Priority Assets", "Reconnaissance"],
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 53, y: 16.5 }, TR: { x: 46, y: 16.5 } },
@@ -14485,7 +14485,7 @@ export const gwTerrain: TerrainConfig = {
     "priority-assets-vs-priority-assets-3": {
       deployment_pattern_id: "tipping-point",
       dispositions: ["Priority Assets", "Priority Assets"],
-      buildings: [
+      templates: [
         {
           type: "large-area",
           corners: { TL: { x: 53, y: 15.5 }, TR: { x: 46, y: 15.5 } },

--- a/src/terrain-config.test.ts
+++ b/src/terrain-config.test.ts
@@ -15,7 +15,7 @@ const terrain: TerrainConfig = {
   templates: { "4x6": { width: 4, height: 6 } },
   layout: {
     "1": {
-      buildings: [{ type: "4x6", corners: { TL: { x: 0, y: 0 }, TR: { x: 4, y: 0 } } }],
+      templates: [{ type: "4x6", corners: { TL: { x: 0, y: 0 }, TR: { x: 4, y: 0 } } }],
     },
   },
 };
@@ -55,7 +55,7 @@ describe("placeholder gw.yml", () => {
 
   it("every building in every layout resolves without throwing", () => {
     for (const [name, layout] of Object.entries(gwTerrain.layout)) {
-      for (const placement of layout.buildings) {
+      for (const placement of layout.templates) {
         expect(
           () => resolveBuilding(placement, gwTerrain.templates, CANVAS),
           `layout ${name}, building type ${placement.type}`,
@@ -88,8 +88,8 @@ describe("getLayoutIcons", () => {
   const t: TerrainConfig = {
     templates: {},
     layout: {
-      "1": { buildings: [], icons: [{ type: "skull", pos: { x: 5, y: 10 } }] },
-      "2": { buildings: [] },
+      "1": { templates: [], icons: [{ type: "skull", pos: { x: 5, y: 10 } }] },
+      "2": { templates: [] },
     },
   };
 
@@ -109,7 +109,7 @@ describe("getLayoutIcons", () => {
     const tp: TerrainConfig = {
       templates: {},
       layout: {
-        "1": { buildings: [], icons: [{ type: "fortress", pos: { x: 5, y: 10 }, player: "attacker" }] },
+        "1": { templates: [], icons: [{ type: "fortress", pos: { x: 5, y: 10 }, player: "attacker" }] },
       },
     };
     expect(getLayoutIcons(tp, "1")).toEqual([
@@ -130,8 +130,8 @@ describe("getLayoutFeatures", () => {
   const t: TerrainConfig = {
     templates: {},
     layout: {
-      "1": { buildings: [], features: [feature] },
-      "2": { buildings: [] },
+      "1": { templates: [], features: [feature] },
+      "2": { templates: [] },
     },
   };
 
@@ -152,12 +152,12 @@ const terrainWithExtras = {
   templates: {},
   layout: {
     a: {
-      buildings: [],
+      templates: [],
       area_terrain: [
         { shape: "polygon", x: 0, y: 0, points: [{ x: 1, y: 1 }], label: "feature" },
       ],
     },
-    bare: { buildings: [] },
+    bare: { templates: [] },
   },
 } as unknown as TerrainConfig;
 

--- a/src/terrain-config.ts
+++ b/src/terrain-config.ts
@@ -58,7 +58,9 @@ export type FeaturePlacement = {
  * external data may instead carry `area_terrain` polygons.
  */
 export type TerrainLayout = {
-  buildings: BuildingPlacement[];
+  // Building placements for this layout. Named `templates` in the YAML
+  // because each placement references a building template by `type:`.
+  templates: BuildingPlacement[];
   icons?: IconPlacement[];
   features?: FeaturePlacement[];
   area_terrain?: AreaTerrain[];
@@ -96,7 +98,7 @@ export function getLayoutBuildings(
   if (!layout) {
     throw new Error(`terrain has no layout named: ${layoutName}`);
   }
-  return layout.buildings;
+  return layout.templates;
 }
 
 /**

--- a/static/data/terrain/combined.yml
+++ b/static/data/terrain/combined.yml
@@ -9,7 +9,7 @@
 
 layout:
   '1':
-    buildings:
+    templates:
       - type: large-pipes
         corners:
           BL:
@@ -122,7 +122,7 @@ layout:
         mirror: false
   gw-11e-crucible:
     deployment_pattern_id: crucible-of-battle
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:
@@ -504,7 +504,7 @@ layout:
         mirror: false
   gw-11e-hammer-anvil:
     deployment_pattern_id: hammer-and-anvil
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:
@@ -961,7 +961,7 @@ layout:
     dispositions:
       - Take and Hold
       - Purge the Foe
-    buildings:
+    templates:
       - type: shoe-mirror
         corners:
           TL:
@@ -1371,7 +1371,7 @@ layout:
     dispositions:
       - Take and Hold
       - Take and Hold
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:
@@ -1781,7 +1781,7 @@ layout:
     dispositions:
       - Take and Hold
       - Take and Hold
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:
@@ -2191,7 +2191,7 @@ layout:
     dispositions:
       - Take and Hold
       - Purge the Foe
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:
@@ -2601,7 +2601,7 @@ layout:
     dispositions:
       - Take and Hold
       - Take and Hold
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -3011,7 +3011,7 @@ layout:
     dispositions:
       - Take and Hold
       - Reconnaissance
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -3421,7 +3421,7 @@ layout:
     dispositions:
       - Take and Hold
       - Disruption
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -3831,7 +3831,7 @@ layout:
     dispositions:
       - Take and Hold
       - Disruption
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -4205,7 +4205,7 @@ layout:
     dispositions:
       - Take and Hold
       - Disruption
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -4612,7 +4612,7 @@ layout:
           'y': 22.25
   sweeping-engagement-1:
     deployment_pattern_id: sweeping-engagement
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -4986,7 +4986,7 @@ layout:
     dispositions:
       - Take and Hold
       - Priority Assets
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:
@@ -5396,7 +5396,7 @@ layout:
     dispositions:
       - Take and Hold
       - Priority Assets
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -5770,7 +5770,7 @@ layout:
     dispositions:
       - Take and Hold
       - Priority Assets
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:
@@ -6180,7 +6180,7 @@ layout:
     dispositions:
       - Take and Hold
       - Reconnaissance
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -6590,7 +6590,7 @@ layout:
     dispositions:
       - Take and Hold
       - Reconnaissance
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -7000,7 +7000,7 @@ layout:
     dispositions:
       - Purge the Foe
       - Purge the Foe
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -7410,7 +7410,7 @@ layout:
     dispositions:
       - Purge the Foe
       - Purge the Foe
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -7820,7 +7820,7 @@ layout:
     dispositions:
       - Purge the Foe
       - Purge the Foe
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -8230,7 +8230,7 @@ layout:
     dispositions:
       - Take and Hold
       - Purge the Foe
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -8640,7 +8640,7 @@ layout:
     dispositions:
       - Disruption
       - Purge the Foe
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -9050,7 +9050,7 @@ layout:
     dispositions:
       - Disruption
       - Purge the Foe
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -9460,7 +9460,7 @@ layout:
     dispositions:
       - Disruption
       - Purge the Foe
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:
@@ -9834,7 +9834,7 @@ layout:
     dispositions:
       - Purge the Foe
       - Reconnaissance
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:
@@ -10244,7 +10244,7 @@ layout:
     dispositions:
       - Purge the Foe
       - Reconnaissance
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:
@@ -10654,7 +10654,7 @@ layout:
     dispositions:
       - Purge the Foe
       - Reconnaissance
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:
@@ -11064,7 +11064,7 @@ layout:
     dispositions:
       - Purge the Foe
       - Priority Assets
-    buildings:
+    templates:
       - type: large-pipes
         corners:
           TL:
@@ -11474,7 +11474,7 @@ layout:
     dispositions:
       - Purge the Foe
       - Priority Assets
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:
@@ -11884,7 +11884,7 @@ layout:
     dispositions:
       - Purge the Foe
       - Priority Assets
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:
@@ -12294,7 +12294,7 @@ layout:
     dispositions:
       - Disruption
       - Disruption
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -12704,7 +12704,7 @@ layout:
     dispositions:
       - Disruption
       - Disruption
-    buildings:
+    templates:
       - type: small-area
         corners:
           TL:
@@ -13114,7 +13114,7 @@ layout:
     dispositions:
       - Disruption
       - Reconnaissance
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -13524,7 +13524,7 @@ layout:
     dispositions:
       - Disruption
       - Priority Assets
-    buildings:
+    templates:
       - type: small-area
         corners:
           TL:
@@ -13934,7 +13934,7 @@ layout:
     dispositions:
       - Disruption
       - Priority Assets
-    buildings:
+    templates:
       - type: small-area
         corners:
           TL:
@@ -14344,7 +14344,7 @@ layout:
     dispositions:
       - Disruption
       - Priority Assets
-    buildings:
+    templates:
       - type: small-area
         corners:
           TL:
@@ -14754,7 +14754,7 @@ layout:
     dispositions:
       - Reconnaissance
       - Reconnaissance
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -15164,7 +15164,7 @@ layout:
     dispositions:
       - Reconnaissance
       - Reconnaissance
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:
@@ -15574,7 +15574,7 @@ layout:
     dispositions:
       - Priority Assets
       - Reconnaissance
-    buildings:
+    templates:
       - type: shoe
         corners:
           TL:
@@ -15984,7 +15984,7 @@ layout:
     dispositions:
       - Priority Assets
       - Reconnaissance
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:
@@ -16394,7 +16394,7 @@ layout:
     dispositions:
       - Priority Assets
       - Priority Assets
-    buildings:
+    templates:
       - type: large-area
         corners:
           TL:

--- a/static/data/terrain/gw.yml
+++ b/static/data/terrain/gw.yml
@@ -14,13 +14,13 @@
 # selects a different canvas corner. Buildings are mirrored 180 degrees
 # through the canvas centre unless `mirror: false`.
 #
-# A layout may also list `icons` (sibling to `buildings`): predefined marker
+# A layout may also list `icons` (sibling to `templates`): predefined marker
 # graphics placed by their circle centre. Each is `{ type: <skull|fortress>,
 # pos: { x, y } }` in inches, with an optional `player: <attacker|defender>`
 # that tints the icon's disk with that player's deployment colour. Icons are
 # styled by theme.yml and drawn on top.
 #
-# A layout may also list `features` (sibling to `buildings`): abstract top-down
+# A layout may also list `features` (sibling to `templates`): abstract top-down
 # terrain pieces — `type` is one of l-ruin, l-ruin-roof, generator, pipe. Each is
 # `{ type, x, y, width, height, color }` in inches (`x`/`y` = top-left of the
 # unrotated bounding box), with an optional `rotation` (degrees about the box
@@ -32,7 +32,7 @@
 
 layout:
   1:
-    buildings:
+    templates:
       - type: large-pipes
         corners: { BL: { x: 12, y: 6 }, TL: { x: 14.5, y: 6 } }
 


### PR DESCRIPTION
## Summary

Renames the layout-level placement key from `buildings` to `templates` across the whole stack. Each placement references a building template by `type:`, so `templates` better describes the list.

## Changes

**Source data**
- `static/data/terrain/gw.yml` — the `buildings:` key under layout `1` → `templates:`, plus its comment references.

**Renderer / types**
- `src/terrain-config.ts` — `TerrainLayout.buildings` → `templates`; `getLayoutBuildings` now returns `layout.templates`.

**Editor**
- `src/editor/scene.ts` — `sceneToConfig` emits `templates:`.
- `src/editor/presets.ts` — `TerrainYaml` type and read loop use `templates`.

**Conversion script**
- `scripts/convert-40kdc-terrain.mjs` — emitted layout key is now `entry.templates`.

**Generated files (regenerated, not hand-edited)**
- `static/data/terrain/combined.yml` via `pnpm convert:40kdc`
- `src/presets/terrain.ts` via `pnpm gen:presets`

**Tests** — updated `terrain-config.test.ts`, `main.test.ts`, `area-terrain-layout.test.ts`, `editor/scene.test.ts`.

## Notes

- Identifier names (`getLayoutBuildings`, the `#buildings` SVG group id, etc.) were intentionally left as-is — only the data key was renamed.
- The merged `TerrainConfig` now has `templates` at two levels: `terrain.templates` (building *definitions*) and `terrain.layout.<id>.templates` (*placements*). TypeScript handles it fine since they're at different nesting levels.

## Verification

`type-check`, `lint`, `convert:40kdc:check`, `gen:presets:check`, full test suite (343 passing), and `build` all green.