### PR TITLE
refactor: unify canvas placement geometry behind a Placed seam

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,33 @@
+# Context — domain glossary
+
+Domain terms for the deployment-map generator. Architecture vocabulary (module,
+interface, seam, depth, adapter) lives in the architecture-review tooling, not here.
+
+## Terms
+
+**Placement** — an instruction for putting one piece on the board, in the form a
+human or the editor authors it. Two authoring shapes exist:
+- *corner-pin* (buildings): pin one or two named template corners (TL/TR/BL/BR) to
+  inward distances from a canvas corner; rotation is *derived* from two corners.
+- *box* (features, area terrain): a top-left `{x, y}`, a `{width, height}` box, and
+  a `rotation` taken about the box centre.
+
+**Placed** — the *canonical resolved form* of a placement, ready to render: a
+template/feature name, a box `{x, y, width, height}` (top-left of the unrotated
+box), and a `rotation` about the box centre. Every authoring shape resolves into a
+`Placed`; every renderer draws a `Placed` with the same `translate(x y) rotate(rot
+cx cy)`. The single representation behind the placement module's seam.
+
+**Resolve** — map an authoring placement to one or more `Placed` (corner-pin → box
+for buildings; identity for already-box features). The forward direction.
+
+**Decompose** — the inverse of resolve: map a `Placed` back to a corner-pin
+`Placement` so the editor can emit building YAML. Lives beside resolve so the
+forward and inverse maps share one convention.
+
+**Mirror** — point-reflect a `Placed` through the canvas centre (`rotation += 180`).
+A piece emits a mirrored copy unless its placement says `mirror: false`; the default
+is *mirror on*. One formula, owned by the placement module.
+
+**Canvas** — the board, `{width, height}` in inches (standard 60×44). Anchors
+(TL/TR/BL/BR) and mirroring are all measured against it.

--- a/scripts/area-to-building.test.mjs
+++ b/scripts/area-to-building.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { areaBuildingPlacement } from "./area-to-building.mjs";
 import { resolvePiece } from "./terrain-resolver.mjs";
-import { resolveBuilding } from "../src/building-coordinates.ts";
+import { resolveBuilding } from "../src/placement.ts";
 
 // gw.yml templates referenced by the converter (subset, incl. shoe-mirror).
 const GW_TEMPLATES = {

--- a/scripts/feature-to-building.test.mjs
+++ b/scripts/feature-to-building.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { featureBuildingPlacement } from "./feature-to-building.mjs";
 import { resolvePiece } from "./terrain-resolver.mjs";
-import { resolveBuilding } from "../src/building-coordinates.ts";
+import { resolveBuilding } from "../src/placement.ts";
 
 const CANVAS = { width: 60, height: 44 };
 

--- a/src/building-coordinates.test.ts
+++ b/src/building-coordinates.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect } from "vitest";
-import {
-  resolveCorner,
-  resolveBuilding,
-  templateBounds,
-  toPoint,
-} from "./building-coordinates";
+import { resolveCorner, templateBounds, toPoint } from "./building-coordinates";
+import { resolveBuilding } from "./placement";
 import type {
   PolygonTemplate,
   PathTemplate,

--- a/src/building-coordinates.ts
+++ b/src/building-coordinates.ts
@@ -155,14 +155,8 @@ export type BuildingPlacement = {
   mirror?: boolean; // default true
 };
 
-export type ResolvedBuilding = {
-  templateName: string;
-  translate: Point;
-  rotation: number; // degrees, [0, 360)
-};
-
 /** Template-local position of a named bounding-box corner. */
-function localCorner(
+export function localCorner(
   corner: Anchor,
   size: { width: number; height: number },
 ): Point {
@@ -179,80 +173,12 @@ function localCorner(
 }
 
 /** Rotates a point about the origin by `rad` radians. */
-function rotate(p: Point, rad: number): Point {
+export function rotate(p: Point, rad: number): Point {
   const cos = Math.cos(rad);
   const sin = Math.sin(rad);
   return { x: p.x * cos - p.y * sin, y: p.x * sin + p.y * cos };
 }
 
-/**
- * Resolves a building placement to one or two ResolvedBuildings (the
- * primary placement, plus a 180-degree point-reflected copy unless
- * `mirror: false`). Throws on an unknown template, a corner count other
- * than 2, or a corner distance that disagrees with the template edge.
- */
-export function resolveBuilding(
-  placement: BuildingPlacement,
-  templates: Record<string, Template>,
-  canvas: CanvasSize,
-): ResolvedBuilding[] {
-  const template = templates[placement.type];
-  if (!template) {
-    throw new Error(
-      `building references unknown template: ${placement.type}`,
-    );
-  }
-  const entries = Object.entries(placement.corners) as [Anchor, CornerSpec][];
-  if (entries.length < 1 || entries.length > 2) {
-    throw new Error(
-      `building ${placement.type}: expected 1 or 2 corners, got ${entries.length}`,
-    );
-  }
-  const defaultFrom: Anchor = placement.from ?? "TL";
-  const size = templateBounds(template, placement.type);
-
-  const [[cornerA, specA]] = entries;
-  const pA = resolveCorner(specA, defaultFrom, canvas);
-  const lA = localCorner(cornerA, size);
-
-  // A single corner pins position with no rotation; a second corner derives
-  // the rotation (and is checked against the template's edge length).
-  let theta = 0;
-  if (entries.length === 2) {
-    const [, [cornerB, specB]] = entries;
-    const pB = resolveCorner(specB, defaultFrom, canvas);
-    const lB = localCorner(cornerB, size);
-
-    const targetLength = Math.hypot(pB.x - pA.x, pB.y - pA.y);
-    const templateLength = Math.hypot(lB.x - lA.x, lB.y - lA.y);
-    if (Math.abs(targetLength - templateLength) > 0.1) {
-      throw new Error(
-        `building ${placement.type}: corners ${cornerA}->${cornerB} measure ` +
-          `${targetLength.toFixed(1)}" apart but template edge is ` +
-          `${templateLength.toFixed(1)}"`,
-      );
-    }
-
-    theta =
-      Math.atan2(pB.y - pA.y, pB.x - pA.x) -
-      Math.atan2(lB.y - lA.y, lB.x - lA.x);
-  }
-  const rotatedLA = rotate(lA, theta);
-  const translate: Point = { x: pA.x - rotatedLA.x, y: pA.y - rotatedLA.y };
-  const rotation = (((theta * 180) / Math.PI) % 360 + 360) % 360;
-
-  const primary: ResolvedBuilding = {
-    templateName: placement.type,
-    translate,
-    rotation,
-  };
-  if (placement.mirror === false) {
-    return [primary];
-  }
-  const mirrored: ResolvedBuilding = {
-    templateName: placement.type,
-    translate: { x: canvas.width - translate.x, y: canvas.height - translate.y },
-    rotation: (rotation + 180) % 360,
-  };
-  return [primary, mirrored];
-}
+// Building placement resolution (corner-pin -> resolved geometry) and the
+// canonical `Placed` form live in `placement.ts`, which builds on these
+// primitives (`resolveCorner`, `templateBounds`, `localCorner`, `rotate`).

--- a/src/buildings.ts
+++ b/src/buildings.ts
@@ -1,6 +1,5 @@
 import { applyAttributes, makeElement } from "./dom-helpers.js";
 import {
-  resolveBuilding,
   toPoint,
   type BuildingPlacement,
   type CanvasSize,
@@ -8,6 +7,7 @@ import {
   type Point,
   type Template,
 } from "./building-coordinates.js";
+import { placeBuildings } from "./placement.js";
 import type { SVGProperties } from "./types.js";
 
 /**
@@ -97,23 +97,24 @@ export function makeBuildings(
   group.setAttribute("id", "buildings");
 
   let counter = 0;
-  for (const placement of placements) {
-    for (const resolved of resolveBuilding(placement, templates, canvas)) {
-      const use = makeElement("use");
-      use.setAttribute("href", `#template-${resolved.templateName}`);
-      use.setAttribute(
-        "transform",
-        `translate(${resolved.translate.x} ${resolved.translate.y}) ` +
-          `rotate(${resolved.rotation})`,
-      );
-      use.setAttribute("id", `building-${counter}`);
-      const props = styleFor?.(resolved.templateName);
-      if (props) {
-        applyAttributes(use, props);
-      }
-      group.appendChild(use);
-      counter++;
+  for (const placed of placeBuildings(placements, templates, canvas)) {
+    const use = makeElement("use");
+    use.setAttribute("href", `#template-${placed.name}`);
+    // rotate's pivot is in the element's local space (applied before
+    // translate), so the box centre is (width/2, height/2) — same convention
+    // features use.
+    use.setAttribute(
+      "transform",
+      `translate(${placed.box.x} ${placed.box.y}) ` +
+        `rotate(${placed.rotation} ${placed.box.width / 2} ${placed.box.height / 2})`,
+    );
+    use.setAttribute("id", `building-${counter}`);
+    const props = styleFor?.(placed.name);
+    if (props) {
+      applyAttributes(use, props);
     }
+    group.appendChild(use);
+    counter++;
   }
   return group;
 }

--- a/src/editor/presets.ts
+++ b/src/editor/presets.ts
@@ -1,4 +1,4 @@
-import { resolveBuilding } from "../building-coordinates.js";
+import { resolveBuilding } from "../placement.js";
 import type { Template, BuildingPlacement, Point } from "../building-coordinates.js";
 import { missions } from "../presets/missions.js";
 import { gwTerrain } from "../presets/terrain.js";

--- a/src/features.ts
+++ b/src/features.ts
@@ -1,6 +1,7 @@
 import type { CanvasSize } from "./building-coordinates.js";
 import { makeElement } from "./dom-helpers.js";
 import { makeShape, type IconShape } from "./icons.js";
+import { resolveFeature } from "./placement.js";
 import type { FeaturePlacement } from "./terrain-config.js";
 import type { Theme } from "./theme.js";
 
@@ -181,19 +182,6 @@ export const features: Record<string, FeatureDraw> = {
   pipe,
 };
 
-/** Point-reflects a placement through the canvas centre (rotation += 180). */
-function mirrorPlacement(
-  placement: FeaturePlacement,
-  canvas: CanvasSize,
-): FeaturePlacement {
-  return {
-    ...placement,
-    x: canvas.width - placement.x - placement.width,
-    y: canvas.height - placement.y - placement.height,
-    rotation: ((placement.rotation ?? 0) + 180) % 360,
-  };
-}
-
 /**
  * Builds `<g id="features">`, one inner `<g>` per placement (translated to its
  * position and rotated about its box center). Body shapes take the palette fill
@@ -217,18 +205,13 @@ export function makeFeatures(
     if (!palette) throw new Error(`unknown feature colour: ${placement.color}`);
 
     const { body, accent } = draw(placement.width, placement.height);
-    const copies =
-      placement.mirror === false
-        ? [placement]
-        : [placement, mirrorPlacement(placement, canvas)];
 
-    for (const copy of copies) {
+    for (const placed of resolveFeature(placement, canvas)) {
       const g = makeElement("g");
-      const rotation = copy.rotation ?? 0;
       g.setAttribute(
         "transform",
-        `translate(${copy.x} ${copy.y}) ` +
-          `rotate(${rotation} ${copy.width / 2} ${copy.height / 2})`,
+        `translate(${placed.box.x} ${placed.box.y}) ` +
+          `rotate(${placed.rotation} ${placed.box.width / 2} ${placed.box.height / 2})`,
       );
       g.setAttribute("id", `feature-${counter}`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export * from "./main.js";
 export * from "./types.js";
 export * from "./theme.js";
 export * from "./building-coordinates.js";
+export * from "./placement.js";
 export * from "./buildings.js";
 export * from "./terrain-config.js";
 export * from "./dom-helpers.js";

--- a/src/placement-characterization.test.ts
+++ b/src/placement-characterization.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment happy-dom
+//
+// CHARACTERIZATION GATE for the origin-pivot -> centre-pivot building switch.
+//
+// The building <use> transform STRING changes shape when buildings move from
+// `translate(tx ty) rotate(deg)` (rotation about the template origin) to
+// `translate(x y) rotate(deg cx cy)` (rotation about the box centre). The
+// rendered GEOMETRY must not. This test reads whatever transform makeBuildings
+// emits, evaluates it on each template's distinctive local points (bbox corners
+// plus polygon vertices, so a nubbin that pokes past the declared box is
+// covered), and snapshots the ABSOLUTE canvas positions. Pixel-identity holds
+// iff this snapshot is unchanged across the refactor.
+import { describe, it, expect } from "vitest";
+import { makeBuildings } from "./buildings";
+import { templateBounds, type Template } from "./building-coordinates";
+
+const canvas = { width: 60, height: 44 };
+
+// A polygon whose geometry pokes past its declared 4x6 box (nubbin to x=5),
+// so the characterization exercises a point outside the placement box under
+// rotation and mirroring.
+const nub: Template = {
+  width: 4,
+  height: 6,
+  points: [
+    { x: 0, y: 0 },
+    { x: 4, y: 0 },
+    { x: 4, y: 2.5 },
+    { x: 5, y: 3 },
+    { x: 4, y: 3.5 },
+    { x: 4, y: 6 },
+    { x: 0, y: 6 },
+  ],
+};
+
+const templates: Record<string, Template> = {
+  "4x6": { width: 4, height: 6 },
+  "3x4": { width: 3, height: 4 },
+  nub,
+};
+
+/** Local points to track per template: polygon vertices, else the bbox corners. */
+function localPoints(name: string): { x: number; y: number }[] {
+  const t = templates[name];
+  if ("points" in t) return t.points;
+  const { width, height } = templateBounds(t, name);
+  return [
+    { x: 0, y: 0 },
+    { x: width, y: 0 },
+    { x: width, y: height },
+    { x: 0, y: height },
+  ];
+}
+
+/**
+ * Parse an SVG transform of the form `translate(a b) rotate(deg[ cx cy])` into
+ * a function mapping a local point to its absolute canvas position. Handles
+ * BOTH the origin-pivot (no cx/cy) and centre-pivot (cx/cy) forms.
+ */
+function evalTransform(transform: string): (p: { x: number; y: number }) => { x: number; y: number } {
+  const tr = /translate\(\s*(-?[\d.]+)\s+(-?[\d.]+)\s*\)/.exec(transform);
+  const ro = /rotate\(\s*(-?[\d.]+)(?:\s+(-?[\d.]+)\s+(-?[\d.]+))?\s*\)/.exec(transform);
+  if (!tr || !ro) throw new Error(`unparsable transform: ${transform}`);
+  const tx = +tr[1], ty = +tr[2];
+  const deg = +ro[1];
+  const cx = ro[2] !== undefined ? +ro[2] : 0;
+  const cy = ro[3] !== undefined ? +ro[3] : 0;
+  const rad = (deg * Math.PI) / 180;
+  const cos = Math.cos(rad), sin = Math.sin(rad);
+  return (p) => {
+    // rotate about (cx,cy), then translate
+    const dx = p.x - cx, dy = p.y - cy;
+    const rxp = cx + dx * cos - dy * sin;
+    const ryp = cy + dx * sin + dy * cos;
+    return { x: tx + rxp, y: ty + ryp };
+  };
+}
+
+/** Render placements, return absolute positions of every tracked local point. */
+function absolutePoints(placements: Parameters<typeof makeBuildings>[0]): string[] {
+  const group = makeBuildings(placements, templates, canvas);
+  const out: string[] = [];
+  for (const use of Array.from(group.querySelectorAll("use"))) {
+    const href = use.getAttribute("href") ?? "";
+    const name = href.replace("#template-", "");
+    const apply = evalTransform(use.getAttribute("transform") ?? "");
+    const abs = localPoints(name).map((p) => {
+      const a = apply(p);
+      return `(${a.x.toFixed(3)}, ${a.y.toFixed(3)})`;
+    });
+    out.push(`${use.getAttribute("id")} ${name}: ${abs.join(" ")}`);
+  }
+  return out;
+}
+
+describe("building geometry is pivot-invariant (characterization gate)", () => {
+  it("axis-aligned, rotated, nubbin, and mirrored buildings land at fixed canvas points", () => {
+    const placements: Parameters<typeof makeBuildings>[0] = [
+      // axis-aligned single corner, mirror on
+      { type: "4x6", corners: { TL: { x: 10, y: 5 } } },
+      // 90-degree rotation via a diagonal corner pair, mirror on
+      { type: "3x4", corners: { TL: { x: 20, y: 10 }, BR: { x: 16, y: 13 } } },
+      // polygon with a nubbin, rotated 90 degrees, mirror on
+      { type: "nub", corners: { TL: { x: 30, y: 8 }, TR: { x: 30, y: 12 } } },
+      // anchored from a non-default canvas corner, mirror off
+      { type: "4x6", mirror: false, corners: { TL: { x: 10, y: 5, from: "TR" } } },
+    ];
+    expect(absolutePoints(placements)).toMatchInlineSnapshot(`
+      [
+        "building-0 4x6: (10.000, 5.000) (14.000, 5.000) (14.000, 11.000) (10.000, 11.000)",
+        "building-1 4x6: (50.000, 39.000) (46.000, 39.000) (46.000, 33.000) (50.000, 33.000)",
+        "building-2 3x4: (20.000, 10.000) (20.000, 13.000) (16.000, 13.000) (16.000, 10.000)",
+        "building-3 3x4: (40.000, 34.000) (40.000, 31.000) (44.000, 31.000) (44.000, 34.000)",
+        "building-4 nub: (30.000, 8.000) (30.000, 12.000) (27.500, 12.000) (27.000, 13.000) (26.500, 12.000) (24.000, 12.000) (24.000, 8.000)",
+        "building-5 nub: (30.000, 36.000) (30.000, 32.000) (32.500, 32.000) (33.000, 31.000) (33.500, 32.000) (36.000, 32.000) (36.000, 36.000)",
+        "building-6 4x6: (50.000, 5.000) (54.000, 5.000) (54.000, 11.000) (50.000, 11.000)",
+      ]
+    `);
+  });
+});

--- a/src/placement.test.ts
+++ b/src/placement.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import {
+  decompose,
+  mirror,
+  placeBuildings,
+  resolveFeature,
+  resolvePlacement,
+  type Placed,
+} from "./placement";
+import type { Template } from "./building-coordinates";
+
+const canvas = { width: 60, height: 44 };
+const templates: Record<string, Template> = {
+  "4x6": { width: 4, height: 6 },
+  "3x4": { width: 3, height: 4 },
+};
+
+describe("resolvePlacement (canonical Placed)", () => {
+  it("resolves a single-corner placement to a centre-pivot box at rotation 0", () => {
+    const [primary] = resolvePlacement(
+      { type: "4x6", mirror: false, corners: { TL: { x: 10, y: 5 } } },
+      templates,
+      canvas,
+    );
+    expect(primary).toEqual({
+      name: "4x6",
+      box: { x: 10, y: 5, width: 4, height: 6 },
+      rotation: 0,
+    });
+  });
+
+  it("keeps the box top-left invariant under a 90-degree rotation", () => {
+    // 3x4 rotated 90deg about its centre: the unrotated box top-left stays the
+    // anchor; rotation is carried separately.
+    const [primary] = resolvePlacement(
+      { type: "3x4", mirror: false, corners: { TL: { x: 20, y: 10 }, BR: { x: 16, y: 13 } } },
+      templates,
+      canvas,
+    );
+    expect(primary.rotation).toBeCloseTo(90, 5);
+    expect(primary.box.width).toBe(3);
+    expect(primary.box.height).toBe(4);
+  });
+
+  it("throws when a corner pair disagrees with the template edge", () => {
+    expect(() =>
+      resolvePlacement(
+        { type: "4x6", corners: { TL: { x: 10, y: 5 }, TR: { x: 20, y: 5 } } },
+        templates,
+        canvas,
+      ),
+    ).toThrow(/measure .* apart but template edge/);
+  });
+
+  it("throws on an unknown template", () => {
+    expect(() =>
+      resolvePlacement({ type: "ghost", corners: { TL: { x: 0, y: 0 } } }, templates, canvas),
+    ).toThrow(/unknown template/);
+  });
+});
+
+describe("mirror default", () => {
+  it("emits a point-reflected copy by default", () => {
+    const result = resolvePlacement(
+      { type: "4x6", corners: { TL: { x: 10, y: 5 } } },
+      templates,
+      canvas,
+    );
+    expect(result).toHaveLength(2);
+    expect(result[1].box).toEqual({ x: 46, y: 33, width: 4, height: 6 });
+    expect(result[1].rotation).toBe(180);
+  });
+
+  it("emits only the primary when mirror is false", () => {
+    expect(
+      resolvePlacement({ type: "4x6", mirror: false, corners: { TL: { x: 10, y: 5 } } }, templates, canvas),
+    ).toHaveLength(1);
+  });
+});
+
+describe("mirror", () => {
+  it("point-reflects a Placed through the canvas centre", () => {
+    const placed: Placed = { name: "x", box: { x: 10, y: 5, width: 4, height: 6 }, rotation: 30 };
+    expect(mirror(placed, canvas)).toEqual({
+      name: "x",
+      box: { x: 46, y: 33, width: 4, height: 6 },
+      rotation: 210,
+    });
+  });
+
+  it("is an involution (modulo the 360 wrap)", () => {
+    const placed: Placed = { name: "x", box: { x: 7, y: 9, width: 5, height: 2 }, rotation: 40 };
+    const back = mirror(mirror(placed, canvas), canvas);
+    expect(back.box).toEqual(placed.box);
+    expect(back.rotation % 360).toBe(placed.rotation % 360);
+  });
+});
+
+describe("resolveFeature", () => {
+  it("treats the placement as the primary box and mirror-expands it", () => {
+    const result = resolveFeature(
+      { type: "pipe", x: 12, y: 6, width: 10, height: 2.5, rotation: 45, color: "rust" },
+      canvas,
+    );
+    expect(result[0]).toEqual({
+      name: "pipe",
+      box: { x: 12, y: 6, width: 10, height: 2.5 },
+      rotation: 45,
+    });
+    expect(result[1].box).toEqual({ x: 38, y: 35.5, width: 10, height: 2.5 });
+    expect(result[1].rotation).toBe(225);
+  });
+});
+
+describe("placeBuildings", () => {
+  it("flattens placements to mirror-expanded Placed", () => {
+    const result = placeBuildings(
+      [
+        { type: "4x6", corners: { TL: { x: 10, y: 5 } } }, // 2 (primary + mirror)
+        { type: "3x4", mirror: false, corners: { TL: { x: 20, y: 10 } } }, // 1
+      ],
+      templates,
+      canvas,
+    );
+    expect(result).toHaveLength(3);
+  });
+});
+
+describe("decompose ∘ resolvePlacement round-trip", () => {
+  // The inverse locks the editor's decomposition to the renderer's forward
+  // resolve — a property that could not be tested when the two lived in
+  // different modules.
+  for (const [label, placement] of [
+    ["axis-aligned", { type: "4x6", mirror: false, corners: { TL: { x: 10, y: 5 } } }],
+    ["rotated 90", { type: "3x4", mirror: false, corners: { TL: { x: 20, y: 10 }, BR: { x: 16, y: 13 } } }],
+  ] as const) {
+    it(`recovers the same Placed (${label})`, () => {
+      const [primary] = resolvePlacement(placement, templates, canvas);
+      const [roundTripped] = resolvePlacement(decompose(primary), templates, canvas);
+      expect(roundTripped.box.x).toBeCloseTo(primary.box.x, 6);
+      expect(roundTripped.box.y).toBeCloseTo(primary.box.y, 6);
+      expect(roundTripped.box.width).toBeCloseTo(primary.box.width, 6);
+      expect(roundTripped.box.height).toBeCloseTo(primary.box.height, 6);
+      expect(roundTripped.rotation).toBeCloseTo(primary.rotation, 6);
+    });
+  }
+});

--- a/src/placement.ts
+++ b/src/placement.ts
@@ -1,0 +1,231 @@
+import {
+  localCorner,
+  resolveCorner,
+  rotate,
+  templateBounds,
+  type Anchor,
+  type BuildingPlacement,
+  type CanvasSize,
+  type CornerSpec,
+  type Point,
+  type Template,
+} from "./building-coordinates.js";
+import type { FeaturePlacement } from "./terrain-config.js";
+
+/** An axis-aligned box in canvas inches; (x,y) is the unrotated top-left. */
+export type Box = { x: number; y: number; width: number; height: number };
+
+/**
+ * The canonical resolved form of any board piece: an unrotated bounding box
+ * plus a rotation taken about the box centre. Every authoring placement
+ * (corner-pin buildings, box features) resolves to a `Placed`, and every
+ * renderer draws it with the same `translate(box.x box.y) rotate(rotation
+ * cx cy)`. This is the single representation behind the placement seam.
+ */
+export type Placed = {
+  name: string;
+  box: Box;
+  rotation: number; // degrees, [0, 360)
+};
+
+/**
+ * Point-reflects a `Placed` through the canvas centre (rotation += 180). The
+ * one mirror formula shared by buildings and features — point reflection is a
+ * rotation by 180 about the centre, so the box's top-left maps to its
+ * opposite and the orientation gains a half-turn.
+ */
+export function mirror(placed: Placed, canvas: CanvasSize): Placed {
+  return {
+    name: placed.name,
+    box: {
+      x: canvas.width - placed.box.x - placed.box.width,
+      y: canvas.height - placed.box.y - placed.box.height,
+      width: placed.box.width,
+      height: placed.box.height,
+    },
+    rotation: (placed.rotation + 180) % 360,
+  };
+}
+
+/**
+ * Applies the mirror default — on unless `mirror: false` — yielding the
+ * primary plus an optional point-reflected copy. The single owner of the
+ * "mirror unless explicitly false" rule.
+ */
+function withMirror(
+  primary: Placed,
+  mirrorFlag: boolean | undefined,
+  canvas: CanvasSize,
+): Placed[] {
+  return mirrorFlag === false ? [primary] : [primary, mirror(primary, canvas)];
+}
+
+/**
+ * Resolves a corner-pin building placement to its primary `Placed` (no
+ * mirror). One corner pins position with no rotation; a second corner derives
+ * the rotation (checked against the template edge). The corner trigonometry
+ * yields an origin-pivot landing point, which is converted to a centre-pivot
+ * box so every `Placed` shares one pivot convention.
+ */
+function resolvePrimary(
+  placement: BuildingPlacement,
+  templates: Record<string, Template>,
+  canvas: CanvasSize,
+): Placed {
+  const template = templates[placement.type];
+  if (!template) {
+    throw new Error(`building references unknown template: ${placement.type}`);
+  }
+  const entries = Object.entries(placement.corners) as [Anchor, CornerSpec][];
+  if (entries.length < 1 || entries.length > 2) {
+    throw new Error(
+      `building ${placement.type}: expected 1 or 2 corners, got ${entries.length}`,
+    );
+  }
+  const defaultFrom: Anchor = placement.from ?? "TL";
+  const size = templateBounds(template, placement.type);
+
+  const [[cornerA, specA]] = entries;
+  const pA = resolveCorner(specA, defaultFrom, canvas);
+  const lA = localCorner(cornerA, size);
+
+  let theta = 0;
+  if (entries.length === 2) {
+    const [, [cornerB, specB]] = entries;
+    const pB = resolveCorner(specB, defaultFrom, canvas);
+    const lB = localCorner(cornerB, size);
+
+    const targetLength = Math.hypot(pB.x - pA.x, pB.y - pA.y);
+    const templateLength = Math.hypot(lB.x - lA.x, lB.y - lA.y);
+    if (Math.abs(targetLength - templateLength) > 0.1) {
+      throw new Error(
+        `building ${placement.type}: corners ${cornerA}->${cornerB} measure ` +
+          `${targetLength.toFixed(1)}" apart but template edge is ` +
+          `${templateLength.toFixed(1)}"`,
+      );
+    }
+
+    theta =
+      Math.atan2(pB.y - pA.y, pB.x - pA.x) -
+      Math.atan2(lB.y - lA.y, lB.x - lA.x);
+  }
+
+  const rotatedLA = rotate(lA, theta);
+  // Origin-pivot landing of the template origin, then converted to a
+  // centre-pivot box: box = translate + (Rot(theta)·c - c).
+  const translate: Point = { x: pA.x - rotatedLA.x, y: pA.y - rotatedLA.y };
+  const rotation = ((((theta * 180) / Math.PI) % 360) + 360) % 360;
+  const c: Point = { x: size.width / 2, y: size.height / 2 };
+  const rc = rotate(c, theta);
+  return {
+    name: placement.type,
+    box: {
+      x: translate.x + rc.x - c.x,
+      y: translate.y + rc.y - c.y,
+      width: size.width,
+      height: size.height,
+    },
+    rotation,
+  };
+}
+
+/**
+ * Resolves a corner-pin building placement to one or two `Placed` (primary,
+ * plus a point-reflected copy unless `mirror: false`). Throws on an unknown
+ * template, a corner count other than 1–2, or a corner distance that
+ * disagrees with the template edge.
+ */
+export function resolvePlacement(
+  placement: BuildingPlacement,
+  templates: Record<string, Template>,
+  canvas: CanvasSize,
+): Placed[] {
+  return withMirror(
+    resolvePrimary(placement, templates, canvas),
+    placement.mirror,
+    canvas,
+  );
+}
+
+/** Flattens a layout's building placements to mirror-expanded `Placed`. */
+export function placeBuildings(
+  placements: BuildingPlacement[],
+  templates: Record<string, Template>,
+  canvas: CanvasSize,
+): Placed[] {
+  return placements.flatMap((p) => resolvePlacement(p, templates, canvas));
+}
+
+/**
+ * Resolves a box-authored feature placement to one or two `Placed` (primary
+ * plus point-reflected copy unless `mirror: false`). Features already carry a
+ * box and a centre rotation, so the primary is the placement verbatim.
+ */
+export function resolveFeature(
+  feature: FeaturePlacement,
+  canvas: CanvasSize,
+): Placed[] {
+  const primary: Placed = {
+    name: feature.type,
+    box: { x: feature.x, y: feature.y, width: feature.width, height: feature.height },
+    rotation: feature.rotation ?? 0,
+  };
+  return withMirror(primary, feature.mirror, canvas);
+}
+
+/**
+ * Inverse of `resolvePlacement`'s primary: encodes a `Placed` as a two-corner
+ * (TL/TR) corner-pin placement that `resolvePlacement` maps back to the same
+ * `Placed`. The corners are the canvas landing points of the template's local
+ * TL and TR under the centre-pivot rotation. `mirror: false` so a re-resolve
+ * yields just the primary.
+ */
+export function decompose(placed: Placed): BuildingPlacement {
+  const { box, rotation, name } = placed;
+  const c: Point = { x: box.width / 2, y: box.height / 2 };
+  const rad = (rotation * Math.PI) / 180;
+  // render(p) = boxTL + c + Rot(theta)(p - c)
+  const render = (p: Point): Point => {
+    const r = rotate({ x: p.x - c.x, y: p.y - c.y }, rad);
+    return { x: box.x + c.x + r.x, y: box.y + c.y + r.y };
+  };
+  const tl = render({ x: 0, y: 0 });
+  const tr = render({ x: box.width, y: 0 });
+  return {
+    type: name,
+    corners: { TL: tl, TR: tr },
+    mirror: false,
+  };
+}
+
+/** Origin-pivot resolved building: the editor's coordinate model. */
+export type ResolvedBuilding = {
+  templateName: string;
+  translate: Point;
+  rotation: number; // degrees, [0, 360)
+};
+
+/** Converts a centre-pivot `Placed` to the editor's origin-pivot form. */
+function placedToOrigin(placed: Placed): ResolvedBuilding {
+  const c: Point = { x: placed.box.width / 2, y: placed.box.height / 2 };
+  const rc = rotate(c, (placed.rotation * Math.PI) / 180);
+  return {
+    templateName: placed.name,
+    translate: { x: placed.box.x + c.x - rc.x, y: placed.box.y + c.y - rc.y },
+    rotation: placed.rotation,
+  };
+}
+
+/**
+ * Resolves a building to origin-pivot `ResolvedBuilding`s (template origin
+ * lands at `translate`, rotation about that origin). Used by the editor, whose
+ * scene model rotates buildings about their top-left corner. A thin adapter
+ * over the centre-pivot `resolvePlacement` so the corner math has one home.
+ */
+export function resolveBuilding(
+  placement: BuildingPlacement,
+  templates: Record<string, Template>,
+  canvas: CanvasSize,
+): ResolvedBuilding[] {
+  return resolvePlacement(placement, templates, canvas).map(placedToOrigin);
+}

--- a/src/terrain-config.test.ts
+++ b/src/terrain-config.test.ts
@@ -9,7 +9,7 @@ import {
   getLayoutAreaTerrain,
   type TerrainConfig,
 } from "./terrain-config";
-import { resolveBuilding } from "./building-coordinates";
+import { resolveBuilding } from "./placement";
 
 const terrain: TerrainConfig = {
   templates: { "4x6": { width: 4, height: 6 } },


### PR DESCRIPTION
## What

Collapses the point-reflection and placement geometry that was scattered across three modules into one deep module, `src/placement.ts`, with a single canonical resolved form:

```ts
Placed = { name, box{ x, y, width, height }, rotation }  // rotation about box centre
```

Every authoring placement — corner-pin buildings and box features — resolves to a `Placed`, and both renderers draw it with the same `translate(box.x box.y) rotate(rot w/2 h/2)`.

## Why

| Concern | Before | After |
|---|---|---|
| 180° mirror formula | 3 copies, 2 offset conventions, 1 inverse | one `mirror(placed, canvas)` |
| "mirror unless false" default | restated in 4 places | one owner |
| Building pivot | origin-pivot (`rotate(deg)`) | centre-pivot — same convention as features |
| Editor `resolveBuilding` | duplicate corner trigonometry | thin adapter over `resolvePlacement` |

`building-coordinates.ts` becomes a primitives module (`resolveCorner`, `templateBounds`, `localCorner`, `rotate`) that `placement.ts` builds on — clean layering rather than a mass rename.

## Safety: the characterization gate

Buildings switch from origin-pivot to centre-pivot rendering. This is geometrically identical — a rigid motion is fixed by orientation plus one fixed point (the pinned corner). `src/placement-characterization.test.ts` proves it: it evaluates whatever transform the renderer emits onto each template's corner points (including a **nubbin that pokes past the declared box**, under rotation and mirroring) and asserts the absolute canvas positions are unchanged.

The gate caught a real bug during development — the rotate pivot belongs in the element's local space, not canvas space — which would have silently shifted every rotated and mirrored building.

## New interface

`placeBuildings`, `resolvePlacement`, `resolveFeature`, `mirror`, `decompose`, and a `resolveBuilding` adapter for the editor's origin-pivot coordinate model. `decompose` is the inverse of `resolvePlacement`, now locked by a **round-trip test** (`resolvePlacement(decompose(p)) ≈ p`) that could not exist when the forward and inverse trig lived in separate modules.

Also adds `CONTEXT.md` with the `Placement` / `Placed` / `Resolve` / `Decompose` / `Mirror` domain glossary.

## Verification

- `pnpm test` — 356 passed (+13 new: characterization gate, `placement.test.ts` interface + round-trip)
- `pnpm type-check` — clean
- `pnpm lint` — clean
- `pnpm build` — both bundles build
- `pnpm gen:presets:check` — presets up to date

Net **−127 / +34** lines in the touched files, plus the new module.